### PR TITLE
Improve vegetation and herbivore interactions

### DIFF
--- a/Assets/1-Scripts/Herbivore.cs
+++ b/Assets/1-Scripts/Herbivore.cs
@@ -38,11 +38,26 @@ public class Herbivore : MonoBehaviour
 
     void FindNewTarget()
     {
-        if (VegetationManager.Instance == null || VegetationManager.Instance.activeVegetation.Count == 0)
+        VegetationTile[] candidates = null;
+
+        if (VegetationManager.Instance != null && VegetationManager.Instance.activeVegetation.Count > 0)
+        {
+            candidates = VegetationManager.Instance.activeVegetation
+                .Where(p => p.isAlive)
+                .ToArray();
+        }
+        else
+        {
+            // Fallback por si el manager aún no se ha inicializado
+            candidates = FindObjectsOfType<VegetationTile>()
+                .Where(p => p.isAlive)
+                .ToArray();
+        }
+
+        if (candidates.Length == 0)
             return;
 
-        targetPlant = VegetationManager.Instance.activeVegetation
-            .Where(p => p.isAlive)
+        targetPlant = candidates
             .OrderBy(p => Vector3.Distance(transform.position, p.transform.position))
             .FirstOrDefault();
     }

--- a/Assets/1-Scripts/VegetationManager.cs
+++ b/Assets/1-Scripts/VegetationManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 public class VegetationManager : MonoBehaviour
@@ -6,6 +7,15 @@ public class VegetationManager : MonoBehaviour
     public static VegetationManager Instance;
 
     public List<VegetationTile> activeVegetation = new List<VegetationTile>();
+
+    [Header("Reproducción")]
+    public GameObject vegetationPrefab;
+    public Vector2 areaSize = new Vector2(50, 50);
+    public float reproductionInterval = 10f;
+    public int maxVegetation = 200;
+    public float minDistanceBetweenPlants = 1f;
+
+    float timer;
 
     void Awake()
     {
@@ -25,5 +35,32 @@ public class VegetationManager : MonoBehaviour
     {
         if (activeVegetation.Contains(tile))
             activeVegetation.Remove(tile);
+    }
+
+    void Update()
+    {
+        timer += Time.deltaTime;
+        if (timer < reproductionInterval)
+            return;
+
+        timer = 0f;
+        if (vegetationPrefab == null || activeVegetation.Count >= maxVegetation)
+            return;
+
+        for (int i = 0; i < 10; i++)
+        {
+            Vector3 pos = new Vector3(
+                Random.Range(-areaSize.x / 2, areaSize.x / 2),
+                0f,
+                Random.Range(-areaSize.y / 2, areaSize.y / 2)
+            );
+
+            bool occupied = activeVegetation.Any(v => Vector3.Distance(v.transform.position, pos) < minDistanceBetweenPlants);
+            if (!occupied)
+            {
+                Instantiate(vegetationPrefab, pos, Quaternion.identity);
+                break;
+            }
+        }
     }
 }

--- a/Assets/1-Scripts/VegetationTile.cs
+++ b/Assets/1-Scripts/VegetationTile.cs
@@ -8,8 +8,9 @@ public class VegetationTile : MonoBehaviour
 
     public bool isAlive => growth > 0f;
 
-    void Awake()
+    void Start()
     {
+        // Registrar la vegetación una vez que el manager esté listo
         VegetationManager.Instance?.Register(this);
     }
 
@@ -21,16 +22,13 @@ public class VegetationTile : MonoBehaviour
 
     void Update()
     {
+        if (growth <= 0f)
+            return;
+
         if (growth < maxGrowth)
         {
             growth += growthRate * Time.deltaTime;
             growth = Mathf.Min(growth, maxGrowth);
-        }
-
-        if (growth <= 1)
-        {
-              Destroy(this.gameObject);
-            Debug.Log("holii");
         }
     }
 
@@ -38,6 +36,10 @@ public class VegetationTile : MonoBehaviour
     {
         float consumed = Mathf.Min(amount, growth);
         growth -= consumed;
+
+        if (growth <= 0f)
+            Destroy(gameObject);
+
         return consumed;
     }
 }


### PR DESCRIPTION
## Summary
- Ensure herbivores can locate vegetation even if the manager isn't ready
- Remove immortal plants by destroying depleted vegetation tiles
- Add reproduction logic so vegetation spreads over time when space permits

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689678ea9a408326b9f61a67ba45149f