### PR TITLE
Improve vegetation growth and herbivore dynamics

### DIFF
--- a/Assets/1-Scripts/Herbivore.cs
+++ b/Assets/1-Scripts/Herbivore.cs
@@ -8,8 +8,13 @@ public class Herbivore : MonoBehaviour
     public float hungerDeathThreshold = 0f;
     public float moveSpeed = 2f;
     public float eatRate = 10f;
+    public float wanderChangeInterval = 3f;
+    public float avoidanceRadius = 0.5f;
 
     public VegetationTile targetPlant;
+
+    Vector3 wanderDir;
+    float wanderTimer;
 
     void Update()
     {
@@ -24,37 +29,71 @@ public class Herbivore : MonoBehaviour
         if (targetPlant == null || !targetPlant.isAlive)
             FindNewTarget();
 
+        Vector3 moveDir = Vector3.zero;
+
         if (targetPlant != null)
         {
-            MoveTowards(targetPlant.transform.position);
+            Vector3 toPlant = targetPlant.transform.position - transform.position;
+            toPlant.y = 0f;
+            moveDir += toPlant.normalized;
 
-            if (Vector3.Distance(transform.position, targetPlant.transform.position) < 1.5f)
+            if (toPlant.magnitude < 1.5f)
             {
                 float eaten = targetPlant.Consume(eatRate * Time.deltaTime);
                 hunger = Mathf.Min(hunger + eaten, 100f);
             }
         }
+        else
+        {
+            wanderTimer -= Time.deltaTime;
+            if (wanderTimer <= 0f)
+            {
+                wanderDir = new Vector3(Random.Range(-1f, 1f), 0f, Random.Range(-1f, 1f)).normalized;
+                wanderTimer = wanderChangeInterval;
+            }
+            moveDir += wanderDir;
+        }
+
+        Collider[] neighbors = Physics.OverlapSphere(transform.position, avoidanceRadius);
+        foreach (var n in neighbors)
+        {
+            if (n.gameObject == gameObject) continue;
+            if (n.GetComponent<Herbivore>() == null) continue;
+
+            Vector3 away = transform.position - n.transform.position;
+            away.y = 0f;
+            if (away.sqrMagnitude > 0.001f)
+                moveDir += away.normalized;
+        }
+
+        if (moveDir.sqrMagnitude > 0.001f)
+            transform.position += moveDir.normalized * moveSpeed * Time.deltaTime;
     }
 
     void FindNewTarget()
     {
-        if (VegetationManager.Instance == null || VegetationManager.Instance.activeVegetation.Count == 0)
+        VegetationTile[] candidates = null;
+
+        if (VegetationManager.Instance != null && VegetationManager.Instance.activeVegetation.Count > 0)
+        {
+            candidates = VegetationManager.Instance.activeVegetation
+                .Where(p => p.isAlive)
+                .ToArray();
+        }
+        else
+        {
+            // Fallback por si el manager aún no se ha inicializado
+            candidates = FindObjectsOfType<VegetationTile>()
+                .Where(p => p.isAlive)
+                .ToArray();
+        }
+
+        if (candidates.Length == 0)
             return;
 
-        targetPlant = VegetationManager.Instance.activeVegetation
-            .Where(p => p.isAlive)
+        targetPlant = candidates
             .OrderBy(p => Vector3.Distance(transform.position, p.transform.position))
             .FirstOrDefault();
-    }
-
-    void MoveTowards(Vector3 target)
-    {
-        Vector3 dir = (target - transform.position);
-        dir.y = 0f; // para evitar subir/bajar en Y si el terreno es plano
-        if (dir.magnitude > 0.1f)
-        {
-            transform.position += dir.normalized * moveSpeed * Time.deltaTime;
-        }
     }
 
     void Die()

--- a/Assets/1-Scripts/VegetationManager.cs
+++ b/Assets/1-Scripts/VegetationManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 public class VegetationManager : MonoBehaviour
@@ -6,6 +7,16 @@ public class VegetationManager : MonoBehaviour
     public static VegetationManager Instance;
 
     public List<VegetationTile> activeVegetation = new List<VegetationTile>();
+
+    [Header("Reproducción")]
+    public GameObject vegetationPrefab;
+    public Vector2 areaSize = new Vector2(50, 50);
+    public float reproductionInterval = 10f;
+    public int maxVegetation = 200;
+    public float minDistanceBetweenPlants = 1f;
+    public float reproductionRadius = 3f;
+
+    float timer;
 
     void Awake()
     {
@@ -25,5 +36,43 @@ public class VegetationManager : MonoBehaviour
     {
         if (activeVegetation.Contains(tile))
             activeVegetation.Remove(tile);
+    }
+
+    void Update()
+    {
+        timer += Time.deltaTime;
+        if (timer < reproductionInterval)
+            return;
+
+        timer = 0f;
+        if (vegetationPrefab == null || activeVegetation.Count >= maxVegetation)
+            return;
+
+        var maturePlants = activeVegetation.Where(v => v.IsMature).ToList();
+        if (maturePlants.Count == 0)
+            return;
+
+        for (int i = 0; i < 10; i++)
+        {
+            var parent = maturePlants[Random.Range(0, maturePlants.Count)];
+            Vector2 offset2 = Random.insideUnitCircle.normalized * Random.Range(minDistanceBetweenPlants, reproductionRadius);
+            Vector3 pos = parent.transform.position + new Vector3(offset2.x, 0f, offset2.y);
+
+            if (!InsideArea(pos))
+                continue;
+
+            bool occupied = activeVegetation.Any(v => Vector3.Distance(v.transform.position, pos) < minDistanceBetweenPlants);
+            if (!occupied)
+            {
+                Instantiate(vegetationPrefab, pos, Quaternion.identity);
+                parent.ReduceGrowthAfterReproduction();
+                break;
+            }
+        }
+    }
+
+    bool InsideArea(Vector3 pos)
+    {
+        return Mathf.Abs(pos.x) <= areaSize.x / 2 && Mathf.Abs(pos.z) <= areaSize.y / 2;
     }
 }

--- a/Assets/1-Scripts/VegetationTile.cs
+++ b/Assets/1-Scripts/VegetationTile.cs
@@ -2,14 +2,19 @@ using UnityEngine;
 
 public class VegetationTile : MonoBehaviour
 {
-    public float growth = 100f;
     public float maxGrowth = 100f;
     public float growthRate = 2f;
+    [Range(0f, 1f)] public float initialGrowthPercent = 0.05f;
+    public float reproductionCost = 30f;
+
+    public float growth;
 
     public bool isAlive => growth > 0f;
+    public bool IsMature => growth >= maxGrowth;
 
-    void Awake()
+    void Start()
     {
+        growth = maxGrowth * initialGrowthPercent;
         VegetationManager.Instance?.Register(this);
     }
 
@@ -21,16 +26,13 @@ public class VegetationTile : MonoBehaviour
 
     void Update()
     {
+        if (growth <= 0f)
+            return;
+
         if (growth < maxGrowth)
         {
             growth += growthRate * Time.deltaTime;
             growth = Mathf.Min(growth, maxGrowth);
-        }
-
-        if (growth <= 1)
-        {
-              Destroy(this.gameObject);
-            Debug.Log("holii");
         }
     }
 
@@ -38,6 +40,17 @@ public class VegetationTile : MonoBehaviour
     {
         float consumed = Mathf.Min(amount, growth);
         growth -= consumed;
+
+        if (growth <= 0f)
+            Destroy(gameObject);
+
         return consumed;
+    }
+
+    public void ReduceGrowthAfterReproduction()
+    {
+        growth -= reproductionCost;
+        if (growth <= 0f)
+            Destroy(gameObject);
     }
 }


### PR DESCRIPTION
## Summary
- Seed new plants at 5% size and let them mature before spreading nearby
- Reproduction now costs growth and spawns vegetation around fully grown plants
- Herbivores wander, seek food, and repel neighbors to reduce overlap

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(hangs: remote host unresponsive)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_689678ea9a408326b9f61a67ba45149f