### PR TITLE
Add meat fertilization, population HUD and camera control

### DIFF
--- a/Assets/1-Scripts/CameraController.cs
+++ b/Assets/1-Scripts/CameraController.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+/// <summary>
+/// Permite mover la cámara en el plano XZ y hacer zoom con la rueda del ratón
+/// para inspeccionar distintas zonas del mapa.
+/// </summary>
+[RequireComponent(typeof(Camera))]
+public class CameraController : MonoBehaviour
+{
+    public float moveSpeed = 10f;
+    public float zoomSpeed = 10f;
+    public float minZoom = 5f;
+    public float maxZoom = 50f;
+
+    Camera cam;
+
+    void Awake()
+    {
+        cam = GetComponent<Camera>();
+    }
+
+    void Update()
+    {
+        float h = Input.GetAxis("Horizontal");
+        float v = Input.GetAxis("Vertical");
+        Vector3 move = new Vector3(h, 0f, v) * moveSpeed * Time.deltaTime;
+        transform.position += move;
+
+        float scroll = Input.GetAxis("Mouse ScrollWheel");
+        if (cam.orthographic)
+        {
+            cam.orthographicSize = Mathf.Clamp(cam.orthographicSize - scroll * zoomSpeed,
+                                              minZoom, maxZoom);
+        }
+        else
+        {
+            cam.fieldOfView = Mathf.Clamp(cam.fieldOfView - scroll * zoomSpeed,
+                                          minZoom, maxZoom);
+        }
+    }
+}

--- a/Assets/1-Scripts/CameraController.cs.meta
+++ b/Assets/1-Scripts/CameraController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e61b8037296446e9bb629d394fca1a5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/1-Scripts/MeatTile.cs
+++ b/Assets/1-Scripts/MeatTile.cs
@@ -9,6 +9,12 @@ public class MeatTile : MonoBehaviour
     public float nutrition = 50f;   // Cantidad de comida disponible
     public float decayRate = 1f;     // Velocidad a la que se pudre
 
+    [Header("Fertilización")] public float fertilizeInterval = 5f;
+    public float fertilizeRadius = 3f;
+    public int fertilizePlants = 1;
+
+    float timer;
+
     public bool isAlive => nutrition > 0f; // Sigue existiendo mientras tenga comida
 
     void Update()
@@ -17,8 +23,18 @@ public class MeatTile : MonoBehaviour
             return;
 
         nutrition -= decayRate * Time.deltaTime;
+        timer += Time.deltaTime;
+        if (timer >= fertilizeInterval)
+        {
+            timer = 0f;
+            VegetationManager.Instance?.FertilizeArea(transform.position, fertilizeRadius, fertilizePlants);
+        }
+
         if (nutrition <= 0f)
+        {
+            VegetationManager.Instance?.FertilizeArea(transform.position, fertilizeRadius, fertilizePlants);
             Destroy(gameObject);
+        }
     }
 
     // Permite a un carnívoro consumir parte de la carne disponiblen
@@ -27,7 +43,10 @@ public class MeatTile : MonoBehaviour
         float eaten = Mathf.Min(amount, nutrition);
         nutrition -= eaten;
         if (nutrition <= 0f)
+        {
+            VegetationManager.Instance?.FertilizeArea(transform.position, fertilizeRadius, fertilizePlants);
             Destroy(gameObject);
+        }
         return eaten;
     }
 }

--- a/Assets/1-Scripts/PopulationDisplay.cs
+++ b/Assets/1-Scripts/PopulationDisplay.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Muestra en pantalla las cantidades actuales de plantas, herbívoros y carnívoros.
+/// Se actualiza cada cuadro para reflejar el estado del sistema.
+/// </summary>
+public class PopulationDisplay : MonoBehaviour
+{
+    public Text plantsText;
+    public Text herbivoresText;
+    public Text carnivoresText;
+
+    void Update()
+    {
+        int plantCount = VegetationManager.Instance != null ?
+            VegetationManager.Instance.activeVegetation.Count : 0;
+        int herbCount = FindObjectsByType<Herbivore>(FindObjectsSortMode.None).Length;
+        int carnCount = FindObjectsByType<Carnivore>(FindObjectsSortMode.None).Length;
+
+        if (plantsText != null)
+            plantsText.text = $"Plantas: {plantCount}";
+        if (herbivoresText != null)
+            herbivoresText.text = $"Herbívoros: {herbCount}";
+        if (carnivoresText != null)
+            carnivoresText.text = $"Carnívoros: {carnCount}";
+    }
+}

--- a/Assets/1-Scripts/PopulationDisplay.cs.meta
+++ b/Assets/1-Scripts/PopulationDisplay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5a97d85189394911bb05ea1d3739d3b1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/1-Scripts/SimulationSpeed.cs
+++ b/Assets/1-Scripts/SimulationSpeed.cs
@@ -1,17 +1,44 @@
 using UnityEngine;
+using UnityEngine.UI;
 
 public class SimulationSpeed : MonoBehaviour
 {
     [Range(0.1f, 10f)]
     public float timeScale = 1f;
 
+    [Header("UI")] public Text timeScaleText;
+    public Slider timeScaleSlider;
+
+    void Start()
+    {
+        if (timeScaleSlider != null)
+        {
+            timeScaleSlider.minValue = 0.1f;
+            timeScaleSlider.maxValue = 10f;
+            timeScaleSlider.value = timeScale;
+            timeScaleSlider.onValueChanged.AddListener(v => timeScale = v);
+        }
+        UpdateText();
+    }
+
     void Update()
     {
+        if (timeScaleSlider != null)
+            timeScaleSlider.value = timeScale;
+
         Time.timeScale = timeScale;
 
         if (Input.GetKeyDown(KeyCode.KeypadPlus) || Input.GetKeyDown(KeyCode.Equals))
             timeScale = Mathf.Min(timeScale * 2f, 10f);
         if (Input.GetKeyDown(KeyCode.KeypadMinus) || Input.GetKeyDown(KeyCode.Minus))
             timeScale = Mathf.Max(timeScale * 0.5f, 0.1f);
+
+        UpdateText();
+    }
+
+    void UpdateText()
+    {
+        if (timeScaleText != null)
+            timeScaleText.text = $"Velocidad: {timeScale:0.0}x";
     }
 }

--- a/Assets/1-Scripts/VegetationManager.cs
+++ b/Assets/1-Scripts/VegetationManager.cs
@@ -64,6 +64,8 @@ public class VegetationManager : MonoBehaviour
                 var parent = maturePlants[Random.Range(0, maturePlants.Count)];
                 Vector2 offset2 = Random.insideUnitCircle.normalized * Random.Range(minDistanceBetweenPlants, reproductionRadius);
                 Vector3 pos = parent.transform.position + new Vector3(offset2.x, 0f, offset2.y);
+                pos.x = Mathf.Clamp(pos.x, -areaSize.x / 2, areaSize.x / 2);
+                pos.z = Mathf.Clamp(pos.z, -areaSize.y / 2, areaSize.y / 2);
 
                 if (!InsideArea(pos))
                     continue;
@@ -97,6 +99,35 @@ public class VegetationManager : MonoBehaviour
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Siembra nuevas plantas alrededor de un punto dado, usado por la carne al descomponerse.
+    /// </summary>
+    public void FertilizeArea(Vector3 center, float radius, int attempts = 1)
+    {
+        if (vegetationPrefab == null || activeVegetation.Count >= maxVegetation)
+            return;
+
+        for (int i = 0; i < attempts; i++)
+        {
+            Vector2 offset = Random.insideUnitCircle * radius;
+            Vector3 pos = center + new Vector3(offset.x, 0f, offset.y);
+            pos.x = Mathf.Clamp(pos.x, -areaSize.x / 2, areaSize.x / 2);
+            pos.z = Mathf.Clamp(pos.z, -areaSize.y / 2, areaSize.y / 2);
+            if (!InsideArea(pos))
+                continue;
+
+            bool occupied = activeVegetation.Any(v => Vector3.Distance(v.transform.position, pos) < minDistanceBetweenPlants);
+            if (!occupied)
+                Instantiate(vegetationPrefab, pos, Quaternion.identity);
+        }
+    }
+
+    void OnDrawGizmosSelected()
+    {
+        Gizmos.color = Color.yellow;
+        Gizmos.DrawWireCube(Vector3.zero, new Vector3(areaSize.x, 0.1f, areaSize.y));
     }
 
     // Comprueba si una posición cae dentro del área válida de juego


### PR DESCRIPTION
## Summary
- allow meat tiles to periodically fertilize surrounding area and spawn plants
- add optional UI controls for time scale and population counts
- introduce camera controller to pan and zoom around the map and visualize map bounds

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_68977772086c8326b83a307251faf64a