### PR TITLE
Optimize entity queries and allocations

### DIFF
--- a/Assets/1-Scripts/MeatTile.cs
+++ b/Assets/1-Scripts/MeatTile.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using System.Collections.Generic;
 
 /// <summary>
 /// Tile de carne que dejan los herbívoros al morir. Se degrada con el tiempo
@@ -6,6 +7,7 @@ using UnityEngine;
 /// </summary>
 public class MeatTile : MonoBehaviour
 {
+    public static readonly List<MeatTile> All = new List<MeatTile>();
     public float nutrition = 50f;   // Cantidad de comida disponible
     public float decayRate = 1f;     // Velocidad a la que se pudre
 
@@ -16,6 +18,11 @@ public class MeatTile : MonoBehaviour
     float timer;
 
     public bool isAlive => nutrition > 0f; // Sigue existiendo mientras tenga comida
+
+    void Awake()
+    {
+        All.Add(this);
+    }
 
     void Update()
     {
@@ -48,5 +55,10 @@ public class MeatTile : MonoBehaviour
             Destroy(gameObject);
         }
         return eaten;
+    }
+
+    void OnDestroy()
+    {
+        All.Remove(this);
     }
 }

--- a/Assets/1-Scripts/PopulationBalancer.cs
+++ b/Assets/1-Scripts/PopulationBalancer.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using System.Collections.Generic;
 
 /// <summary>
 /// Monitors the populations of plants, herbivores and carnivores and
@@ -49,10 +50,10 @@ public class PopulationBalancer : MonoBehaviour
         // Sample populations (similar to PopulationGraph.Update)
         currentPlants = VegetationManager.Instance != null ?
             VegetationManager.Instance.activeVegetation.Count : 0;
-        Herbivore[] herbArray = FindObjectsByType<Herbivore>(FindObjectsSortMode.None);
-        Carnivore[] carnArray = FindObjectsByType<Carnivore>(FindObjectsSortMode.None);
-        currentHerbivores = herbArray.Length;
-        currentCarnivores = carnArray.Length;
+        List<Herbivore> herbArray = Herbivore.All;
+        List<Carnivore> carnArray = Carnivore.All;
+        currentHerbivores = herbArray.Count;
+        currentCarnivores = carnArray.Count;
 
         // Herbivore balancing
         if (currentHerbivores < minHerbivores)
@@ -77,26 +78,26 @@ public class PopulationBalancer : MonoBehaviour
         }
     }
 
-    void AdjustHerbivoreReproduction(Herbivore[] herd, float threshold)
+    void AdjustHerbivoreReproduction(List<Herbivore> herd, float threshold)
     {
         foreach (var h in herd)
             h.reproductionThreshold = threshold;
     }
 
-    void AdjustCarnivoreReproduction(Carnivore[] pack, float threshold)
+    void AdjustCarnivoreReproduction(List<Carnivore> pack, float threshold)
     {
         foreach (var c in pack)
             c.reproductionThreshold = threshold;
     }
 
-    void SpawnNearExisting(GameObject prefab, Component[] existing)
+    void SpawnNearExisting<T>(GameObject prefab, List<T> existing) where T : MonoBehaviour
     {
-        if (prefab == null || existing == null || existing.Length == 0)
+        if (prefab == null || existing == null || existing.Count == 0)
             return;
 
         for (int i = 0; i < spawnAmount; i++)
         {
-            Vector3 origin = existing[Random.Range(0, existing.Length)].transform.position;
+            Vector3 origin = existing[Random.Range(0, existing.Count)].transform.position;
             Vector3 pos = origin + new Vector3(Random.Range(-spawnRadius, spawnRadius), 0f,
                                               Random.Range(-spawnRadius, spawnRadius));
             Instantiate(prefab, pos, Quaternion.identity);

--- a/Assets/1-Scripts/PopulationDisplay.cs
+++ b/Assets/1-Scripts/PopulationDisplay.cs
@@ -16,8 +16,8 @@ public class PopulationDisplay : MonoBehaviour
     {
         int plantCount = VegetationManager.Instance != null ?
             VegetationManager.Instance.activeVegetation.Count : 0;
-        int herbCount = FindObjectsByType<Herbivore>(FindObjectsSortMode.None).Length;
-        int carnCount = FindObjectsByType<Carnivore>(FindObjectsSortMode.None).Length;
+        int herbCount = Herbivore.All.Count;
+        int carnCount = Carnivore.All.Count;
 
         if (plantsText != null)
             plantsText.text = $"Plantas: {plantCount}";

--- a/Assets/1-Scripts/PopulationGraph.cs
+++ b/Assets/1-Scripts/PopulationGraph.cs
@@ -27,8 +27,8 @@ public class PopulationGraph : MonoBehaviour
         samples++;
 
         int plantCount = VegetationManager.Instance != null ? VegetationManager.Instance.activeVegetation.Count : 0;
-        int herbCount = FindObjectsByType<Herbivore>(FindObjectsSortMode.None).Length;
-        int carnCount = FindObjectsByType<Carnivore>(FindObjectsSortMode.None).Length;
+        int herbCount = Herbivore.All.Count;
+        int carnCount = Carnivore.All.Count;
 
         AddPoint(plantsLine, plantPoints, plantCount);
         AddPoint(herbivoresLine, herbPoints, herbCount);

--- a/Assets/1-Scripts/VegetationManager.cs
+++ b/Assets/1-Scripts/VegetationManager.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 
 /// <summary>
@@ -56,7 +55,13 @@ public class VegetationManager : MonoBehaviour
             return;
 
         // Intentamos generar alrededor de plantas maduras
-        var maturePlants = activeVegetation.Where(v => v.IsMature).ToList();
+        List<VegetationTile> maturePlants = new List<VegetationTile>();
+        for (int i = 0; i < activeVegetation.Count; i++)
+        {
+            var v = activeVegetation[i];
+            if (v != null && v.IsMature)
+                maturePlants.Add(v);
+        }
         if (maturePlants.Count > 0)
         {
             for (int i = 0; i < 10; i++)
@@ -70,7 +75,15 @@ public class VegetationManager : MonoBehaviour
                 if (!InsideArea(pos))
                     continue;
 
-                bool occupied = activeVegetation.Any(v => Vector3.Distance(v.transform.position, pos) < minDistanceBetweenPlants);
+                bool occupied = false;
+                for (int j = 0; j < activeVegetation.Count; j++)
+                {
+                    if (Vector3.Distance(activeVegetation[j].transform.position, pos) < minDistanceBetweenPlants)
+                    {
+                        occupied = true;
+                        break;
+                    }
+                }
                 if (!occupied)
                 {
                     Instantiate(vegetationPrefab, pos, Quaternion.identity);
@@ -91,7 +104,15 @@ public class VegetationManager : MonoBehaviour
                     0f,
                     Random.Range(-areaSize.y / 2, areaSize.y / 2));
 
-                bool occupied = activeVegetation.Any(v => Vector3.Distance(v.transform.position, pos) < minDistanceBetweenPlants);
+                bool occupied = false;
+                for (int j = 0; j < activeVegetation.Count; j++)
+                {
+                    if (Vector3.Distance(activeVegetation[j].transform.position, pos) < minDistanceBetweenPlants)
+                    {
+                        occupied = true;
+                        break;
+                    }
+                }
                 if (!occupied)
                 {
                     Instantiate(vegetationPrefab, pos, Quaternion.identity);
@@ -118,7 +139,15 @@ public class VegetationManager : MonoBehaviour
             if (!InsideArea(pos))
                 continue;
 
-            bool occupied = activeVegetation.Any(v => Vector3.Distance(v.transform.position, pos) < minDistanceBetweenPlants);
+            bool occupied = false;
+            for (int j = 0; j < activeVegetation.Count; j++)
+            {
+                if (Vector3.Distance(activeVegetation[j].transform.position, pos) < minDistanceBetweenPlants)
+                {
+                    occupied = true;
+                    break;
+                }
+            }
             if (!occupied)
                 Instantiate(vegetationPrefab, pos, Quaternion.identity);
         }


### PR DESCRIPTION
## Summary
- Track herbivores, carnivores and meat tiles in static lists to avoid costly FindObjectsByType calls
- Replace LINQ usage and Physics.OverlapSphere allocations with manual loops and OverlapSphereNonAlloc
- Update population managers and displays to use cached lists for counts

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6897a29f14d8832694f1d7ffcf2081db