### PR TITLE
Optimize entity queries and allocations

### DIFF
--- a/Assets/1-Scripts/FpsCounter.cs
+++ b/Assets/1-Scripts/FpsCounter.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+using TMPro;
+
+/// <summary>
+/// Muestra los FPS actuales en pantalla.
+/// </summary>
+public class FpsCounter : MonoBehaviour
+{
+    public TextMeshProUGUI display;
+    float timer;
+    int frames;
+
+    void Update()
+    {
+        frames++;
+        timer += Time.unscaledDeltaTime;
+        if (timer >= 1f)
+        {
+            if (display != null)
+                display.text = $"{frames / timer:0} FPS";
+            frames = 0;
+            timer = 0f;
+        }
+    }
+}

--- a/Assets/1-Scripts/FpsCounter.cs.meta
+++ b/Assets/1-Scripts/FpsCounter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8e93b364e6f143a4acbf48d76ed1ba1d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/1-Scripts/FpsLimiter.cs
+++ b/Assets/1-Scripts/FpsLimiter.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+/// <summary>
+/// Limita la tasa de refresco para estabilizar los FPS.
+/// </summary>
+public class FpsLimiter : MonoBehaviour
+{
+    [Range(30, 240)] public int targetFps = 60;
+
+    void Awake()
+    {
+        QualitySettings.vSyncCount = 0; // Permite que Application.targetFrameRate funcione
+        Application.targetFrameRate = targetFps;
+    }
+}

--- a/Assets/1-Scripts/FpsLimiter.cs.meta
+++ b/Assets/1-Scripts/FpsLimiter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6b74beb6c0224dcda4841069a35f9872
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/1-Scripts/Herbivore.cs
+++ b/Assets/1-Scripts/Herbivore.cs
@@ -1,5 +1,5 @@
 using UnityEngine;
-using System.Linq;
+using System.Collections.Generic;
 
 /// <summary>
 /// Controla el comportamiento de un herbívoro: búsqueda de plantas,
@@ -8,6 +8,10 @@ using System.Linq;
 /// </summary>
 public class Herbivore : MonoBehaviour
 {
+    public static readonly List<Herbivore> All = new List<Herbivore>();
+    static readonly Collider[] predatorBuffer = new Collider[32];
+    static readonly Collider[] neighborBuffer = new Collider[32];
+    static readonly Collider[] plantCheckBuffer = new Collider[32];
     public float maxHunger = 100f;
     public float hunger = 100f;
     public float hungerRate = 5f;               // Velocidad a la que pierde hambre
@@ -43,6 +47,10 @@ public class Herbivore : MonoBehaviour
     Color baseColor;                             // Color original
     Vector3 baseScale;                          // Escala base para crecimiento
     bool wasHurt;                               // Señal cuando recibe daño
+    [Header("Rendimiento")]
+    [Tooltip("Tiempo en segundos entre actualizaciones de lógica")]
+    [Range(0.02f, 1f)] public float updateInterval = 0.1f;
+    float updateTimer;
 
     enum HerbivoreState { Wandering, Eating, Fleeing, SeekingMate }
     HerbivoreState state = HerbivoreState.Wandering;
@@ -55,12 +63,24 @@ public class Herbivore : MonoBehaviour
         baseScale = transform.localScale;
         health = maxHealth * 0.2f; // Nacen con 20% de vida
         UpdateScale();
+        All.Add(this);
+    }
+
+    void OnDestroy()
+    {
+        All.Remove(this);
     }
 
     void Update()
     {
+        updateTimer += Time.deltaTime;
+        if (updateTimer < updateInterval)
+            return;
+        float dt = updateTimer;
+        updateTimer = 0f;
+
         // Actualizar hambre y comprobar muerte
-        hunger -= hungerRate * Time.deltaTime;
+        hunger -= hungerRate * dt;
         if (hunger <= hungerDeathThreshold)
         {
             Die();
@@ -71,7 +91,7 @@ public class Herbivore : MonoBehaviour
             hunger = maxHunger;
 
         // Actualizar enfriamientos y objetivos
-        reproductionTimer -= Time.deltaTime;
+        reproductionTimer -= dt;
         if (hunger <= seekThreshold && targetPlant == null)
             FindNewTarget();
 
@@ -79,12 +99,13 @@ public class Herbivore : MonoBehaviour
         HerbivoreState newState = HerbivoreState.Wandering;
 
         // 1. Depredadores cercanos -> huir en dirección opuesta a todos ellos
-        Collider[] predators = Physics.OverlapSphere(transform.position, predatorDetection);
+        int predatorCount = Physics.OverlapSphereNonAlloc(transform.position, predatorDetection, predatorBuffer);
         Vector3 fleeDirection = Vector3.zero;
         bool predatorNearby = false;
-        foreach (var p in predators)
+        for (int i = 0; i < predatorCount; i++)
         {
-            if (p.GetComponent<Carnivore>() == null) continue;
+            var p = predatorBuffer[i];
+            if (p == null || p.GetComponent<Carnivore>() == null) continue;
             predatorNearby = true;
             Vector3 away = transform.position - p.transform.position;
             away.y = 0f;
@@ -129,7 +150,7 @@ public class Herbivore : MonoBehaviour
                 toPlant.y = 0f;
                 if (toPlant.magnitude < 1.5f)
                 {
-                    float eaten = targetPlant.Consume(eatRate * Time.deltaTime);
+                    float eaten = targetPlant.Consume(eatRate * dt);
                     hunger = Mathf.Min(hunger + eaten, maxHunger);
                     health = Mathf.Min(health + eaten, maxHealth);
                     UpdateScale();
@@ -164,7 +185,7 @@ public class Herbivore : MonoBehaviour
                 break;
 
             case HerbivoreState.Wandering:
-                wanderTimer -= Time.deltaTime;
+                wanderTimer -= dt;
                 if (wanderTimer <= 0f)
                 {
                     wanderDir = new Vector3(Random.Range(-1f, 1f), 0f, Random.Range(-1f, 1f)).normalized;
@@ -177,10 +198,11 @@ public class Herbivore : MonoBehaviour
         // Evitar superposición con otros herbívoros
         if (state != HerbivoreState.Eating)
         {
-            Collider[] neighbors = Physics.OverlapSphere(transform.position, avoidanceRadius);
-            foreach (var n in neighbors)
+            int neighborCount = Physics.OverlapSphereNonAlloc(transform.position, avoidanceRadius, neighborBuffer);
+            for (int i = 0; i < neighborCount; i++)
             {
-                if (n.gameObject == gameObject) continue;
+                var n = neighborBuffer[i];
+                if (n == null || n.gameObject == gameObject) continue;
                 if (n.GetComponent<Herbivore>() == null) continue;
 
                 Vector3 away = transform.position - n.transform.position;
@@ -198,7 +220,7 @@ public class Herbivore : MonoBehaviour
                 speed = runSpeed;
 
             Vector3 dir = moveDir.normalized;
-            transform.position += dir * speed * Time.deltaTime;
+            transform.position += dir * speed * dt;
             transform.rotation = Quaternion.LookRotation(dir);
             ClampToBounds();
         }
@@ -209,45 +231,60 @@ public class Herbivore : MonoBehaviour
     // Busca la planta viva más cercana dentro del radio de detección
     void FindNewTarget()
     {
-        VegetationTile[] candidates = null;
-
-        if (VegetationManager.Instance != null && VegetationManager.Instance.activeVegetation.Count > 0)
-        {
-            candidates = VegetationManager.Instance.activeVegetation
-                .Where(p => p.isAlive &&
-                       Vector3.Distance(transform.position, p.transform.position) <= detectionRadius &&
-                       !Physics.OverlapSphere(p.transform.position, predatorDetection)
-                           .Any(c => c.GetComponent<Carnivore>() != null))
-                .ToArray();
-        }
-        else
-        {
-            // Búsqueda de respaldo en caso de que el manager no esté listo
-            candidates = FindObjectsByType<VegetationTile>(FindObjectsSortMode.None)
-                .Where(p => p.isAlive &&
-                       Vector3.Distance(transform.position, p.transform.position) <= detectionRadius &&
-                       !Physics.OverlapSphere(p.transform.position, predatorDetection)
-                           .Any(c => c.GetComponent<Carnivore>() != null))
-                .ToArray();
-        }
-
-        if (candidates.Length == 0)
+        if (VegetationManager.Instance == null)
+            return;
+        var plants = VegetationManager.Instance.activeVegetation;
+        if (plants == null || plants.Count == 0)
             return;
 
-        targetPlant = candidates
-            .OrderBy(p => Vector3.Distance(transform.position, p.transform.position))
-            .FirstOrDefault();
+        float closest = float.MaxValue;
+        VegetationTile closestPlant = null;
+        for (int i = 0; i < plants.Count; i++)
+        {
+            var p = plants[i];
+            if (p == null || !p.isAlive)
+                continue;
+            float dist = Vector3.Distance(transform.position, p.transform.position);
+            if (dist > detectionRadius)
+                continue;
+            int count = Physics.OverlapSphereNonAlloc(p.transform.position, predatorDetection, plantCheckBuffer);
+            bool danger = false;
+            for (int j = 0; j < count; j++)
+            {
+                if (plantCheckBuffer[j] != null && plantCheckBuffer[j].GetComponent<Carnivore>() != null)
+                {
+                    danger = true;
+                    break;
+                }
+            }
+            if (danger)
+                continue;
+            if (dist < closest)
+            {
+                closest = dist;
+                closestPlant = p;
+            }
+        }
+        targetPlant = closestPlant;
     }
 
     // Busca un compañero disponible dentro del radio de búsqueda
     Herbivore FindPartner()
     {
-        Herbivore[] herd = FindObjectsByType<Herbivore>(FindObjectsSortMode.None)
-            .Where(h => h != this && h.hunger >= reproductionThreshold && h.reproductionTimer <= 0f &&
-                   Vector3.Distance(transform.position, h.transform.position) <= reproductionSeekRadius)
-            .ToArray();
-        if (herd.Length == 0) return null;
-        return herd.OrderBy(h => Vector3.Distance(transform.position, h.transform.position)).FirstOrDefault();
+        Herbivore best = null;
+        float bestDist = float.MaxValue;
+        foreach (var h in All)
+        {
+            if (h == this) continue;
+            if (h.hunger < reproductionThreshold || h.reproductionTimer > 0f) continue;
+            float dist = Vector3.Distance(transform.position, h.transform.position);
+            if (dist <= reproductionSeekRadius && dist < bestDist)
+            {
+                bestDist = dist;
+                best = h;
+            }
+        }
+        return best;
     }
 
     // Instancia una nueva cría y reduce el hambre de los padres

--- a/Assets/1-Scripts/MeatTile.cs
+++ b/Assets/1-Scripts/MeatTile.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using System.Collections.Generic;
 
 /// <summary>
 /// Tile de carne que dejan los herbívoros al morir. Se degrada con el tiempo
@@ -6,6 +7,7 @@ using UnityEngine;
 /// </summary>
 public class MeatTile : MonoBehaviour
 {
+    public static readonly List<MeatTile> All = new List<MeatTile>();
     public float nutrition = 50f;   // Cantidad de comida disponible
     public float decayRate = 1f;     // Velocidad a la que se pudre
 
@@ -16,6 +18,11 @@ public class MeatTile : MonoBehaviour
     float timer;
 
     public bool isAlive => nutrition > 0f; // Sigue existiendo mientras tenga comida
+
+    void Awake()
+    {
+        All.Add(this);
+    }
 
     void Update()
     {
@@ -48,5 +55,10 @@ public class MeatTile : MonoBehaviour
             Destroy(gameObject);
         }
         return eaten;
+    }
+
+    void OnDestroy()
+    {
+        All.Remove(this);
     }
 }

--- a/Assets/1-Scripts/PopulationBalancer.cs
+++ b/Assets/1-Scripts/PopulationBalancer.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using System.Collections.Generic;
 
 /// <summary>
 /// Monitors the populations of plants, herbivores and carnivores and
@@ -49,10 +50,10 @@ public class PopulationBalancer : MonoBehaviour
         // Sample populations (similar to PopulationGraph.Update)
         currentPlants = VegetationManager.Instance != null ?
             VegetationManager.Instance.activeVegetation.Count : 0;
-        Herbivore[] herbArray = FindObjectsByType<Herbivore>(FindObjectsSortMode.None);
-        Carnivore[] carnArray = FindObjectsByType<Carnivore>(FindObjectsSortMode.None);
-        currentHerbivores = herbArray.Length;
-        currentCarnivores = carnArray.Length;
+        List<Herbivore> herbArray = Herbivore.All;
+        List<Carnivore> carnArray = Carnivore.All;
+        currentHerbivores = herbArray.Count;
+        currentCarnivores = carnArray.Count;
 
         // Herbivore balancing
         if (currentHerbivores < minHerbivores)
@@ -77,26 +78,26 @@ public class PopulationBalancer : MonoBehaviour
         }
     }
 
-    void AdjustHerbivoreReproduction(Herbivore[] herd, float threshold)
+    void AdjustHerbivoreReproduction(List<Herbivore> herd, float threshold)
     {
         foreach (var h in herd)
             h.reproductionThreshold = threshold;
     }
 
-    void AdjustCarnivoreReproduction(Carnivore[] pack, float threshold)
+    void AdjustCarnivoreReproduction(List<Carnivore> pack, float threshold)
     {
         foreach (var c in pack)
             c.reproductionThreshold = threshold;
     }
 
-    void SpawnNearExisting(GameObject prefab, Component[] existing)
+    void SpawnNearExisting<T>(GameObject prefab, List<T> existing) where T : MonoBehaviour
     {
-        if (prefab == null || existing == null || existing.Length == 0)
+        if (prefab == null || existing == null || existing.Count == 0)
             return;
 
         for (int i = 0; i < spawnAmount; i++)
         {
-            Vector3 origin = existing[Random.Range(0, existing.Length)].transform.position;
+            Vector3 origin = existing[Random.Range(0, existing.Count)].transform.position;
             Vector3 pos = origin + new Vector3(Random.Range(-spawnRadius, spawnRadius), 0f,
                                               Random.Range(-spawnRadius, spawnRadius));
             Instantiate(prefab, pos, Quaternion.identity);

--- a/Assets/1-Scripts/PopulationDisplay.cs
+++ b/Assets/1-Scripts/PopulationDisplay.cs
@@ -16,8 +16,8 @@ public class PopulationDisplay : MonoBehaviour
     {
         int plantCount = VegetationManager.Instance != null ?
             VegetationManager.Instance.activeVegetation.Count : 0;
-        int herbCount = FindObjectsByType<Herbivore>(FindObjectsSortMode.None).Length;
-        int carnCount = FindObjectsByType<Carnivore>(FindObjectsSortMode.None).Length;
+        int herbCount = Herbivore.All.Count;
+        int carnCount = Carnivore.All.Count;
 
         if (plantsText != null)
             plantsText.text = $"Plantas: {plantCount}";

--- a/Assets/1-Scripts/PopulationGraph.cs
+++ b/Assets/1-Scripts/PopulationGraph.cs
@@ -27,8 +27,8 @@ public class PopulationGraph : MonoBehaviour
         samples++;
 
         int plantCount = VegetationManager.Instance != null ? VegetationManager.Instance.activeVegetation.Count : 0;
-        int herbCount = FindObjectsByType<Herbivore>(FindObjectsSortMode.None).Length;
-        int carnCount = FindObjectsByType<Carnivore>(FindObjectsSortMode.None).Length;
+        int herbCount = Herbivore.All.Count;
+        int carnCount = Carnivore.All.Count;
 
         AddPoint(plantsLine, plantPoints, plantCount);
         AddPoint(herbivoresLine, herbPoints, herbCount);

--- a/Assets/1-Scripts/VegetationManager.cs
+++ b/Assets/1-Scripts/VegetationManager.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 
 /// <summary>
@@ -56,7 +55,13 @@ public class VegetationManager : MonoBehaviour
             return;
 
         // Intentamos generar alrededor de plantas maduras
-        var maturePlants = activeVegetation.Where(v => v.IsMature).ToList();
+        List<VegetationTile> maturePlants = new List<VegetationTile>();
+        for (int i = 0; i < activeVegetation.Count; i++)
+        {
+            var v = activeVegetation[i];
+            if (v != null && v.IsMature)
+                maturePlants.Add(v);
+        }
         if (maturePlants.Count > 0)
         {
             for (int i = 0; i < 10; i++)
@@ -70,7 +75,15 @@ public class VegetationManager : MonoBehaviour
                 if (!InsideArea(pos))
                     continue;
 
-                bool occupied = activeVegetation.Any(v => Vector3.Distance(v.transform.position, pos) < minDistanceBetweenPlants);
+                bool occupied = false;
+                for (int j = 0; j < activeVegetation.Count; j++)
+                {
+                    if (Vector3.Distance(activeVegetation[j].transform.position, pos) < minDistanceBetweenPlants)
+                    {
+                        occupied = true;
+                        break;
+                    }
+                }
                 if (!occupied)
                 {
                     Instantiate(vegetationPrefab, pos, Quaternion.identity);
@@ -91,7 +104,15 @@ public class VegetationManager : MonoBehaviour
                     0f,
                     Random.Range(-areaSize.y / 2, areaSize.y / 2));
 
-                bool occupied = activeVegetation.Any(v => Vector3.Distance(v.transform.position, pos) < minDistanceBetweenPlants);
+                bool occupied = false;
+                for (int j = 0; j < activeVegetation.Count; j++)
+                {
+                    if (Vector3.Distance(activeVegetation[j].transform.position, pos) < minDistanceBetweenPlants)
+                    {
+                        occupied = true;
+                        break;
+                    }
+                }
                 if (!occupied)
                 {
                     Instantiate(vegetationPrefab, pos, Quaternion.identity);
@@ -118,7 +139,15 @@ public class VegetationManager : MonoBehaviour
             if (!InsideArea(pos))
                 continue;
 
-            bool occupied = activeVegetation.Any(v => Vector3.Distance(v.transform.position, pos) < minDistanceBetweenPlants);
+            bool occupied = false;
+            for (int j = 0; j < activeVegetation.Count; j++)
+            {
+                if (Vector3.Distance(activeVegetation[j].transform.position, pos) < minDistanceBetweenPlants)
+                {
+                    occupied = true;
+                    break;
+                }
+            }
             if (!occupied)
                 Instantiate(vegetationPrefab, pos, Quaternion.identity);
         }


### PR DESCRIPTION
## Summary
- Throttle herbivore and carnivore logic with configurable update intervals
- Add scripts to limit frame rate and display current FPS

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6897a29f14d8832694f1d7ffcf2081db