### PR TITLE
Keep population graph visible and clarify FPS counter

### DIFF
--- a/Assets/1-Scripts/FpsCounter.cs
+++ b/Assets/1-Scripts/FpsCounter.cs
@@ -13,6 +13,7 @@ public class FpsCounter : MonoBehaviour
     void Update()
     {
         frames++;
+        // Time.unscaledDeltaTime evita que el contador se vea afectado por la escala de tiempo
         timer += Time.unscaledDeltaTime;
         if (timer >= 1f)
         {

--- a/Assets/1-Scripts/PopulationGraph.cs
+++ b/Assets/1-Scripts/PopulationGraph.cs
@@ -12,6 +12,7 @@ public class PopulationGraph : MonoBehaviour
     public LineRenderer carnivoresLine;
     public float sampleInterval = 1f; // Tiempo entre muestras
     public float yScale = 0.1f;       // Escala vertical para las cantidades
+    public int maxSamples = 200;      // Muestras visibles en el gráfico
 
     float timer;
     int samples;
@@ -40,6 +41,18 @@ public class PopulationGraph : MonoBehaviour
         if (lr == null) return;
         Vector3 point = new Vector3(samples, value * yScale, 0f);
         list.Add(point);
+
+        if (list.Count > maxSamples)
+        {
+            list.RemoveAt(0);
+            for (int i = 0; i < list.Count; i++)
+            {
+                Vector3 p = list[i];
+                p.x -= 1f; // Desplaza las muestras para mantenerlas visibles
+                list[i] = p;
+            }
+        }
+
         lr.positionCount = list.Count;
         lr.SetPositions(list.ToArray());
     }


### PR DESCRIPTION
## Summary
- Limit population graph to a fixed number of samples and shift points so it stays on screen
- Clarify FPS counter uses unscaled time so it's independent of time scale changes

## Testing
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package dotnet-sdk-7.0)*

------
https://chatgpt.com/codex/tasks/task_b_6897c2fe2df08326837bbfa40987a4d1