### PR TITLE
Add UI toggle and ecosystem tuning panel

### DIFF
--- a/Assets/1-Scripts/EcosystemSettingsUI.cs
+++ b/Assets/1-Scripts/EcosystemSettingsUI.cs
@@ -1,0 +1,77 @@
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+/// <summary>
+/// Permite ajustar parámetros clave del ecosistema en tiempo real desde un panel.
+/// </summary>
+public class EcosystemSettingsUI : MonoBehaviour
+{
+    [Header("Referencias")]
+    public VegetationManager vegetationManager;
+    public PopulationBalancer populationBalancer;
+
+    [Header("UI")]
+    public Slider plantReproductionSlider;
+    public TextMeshProUGUI plantReproductionText;
+    public Slider herbivoreMinSlider;
+    public TextMeshProUGUI herbivoreMinText;
+    public Slider carnivoreMinSlider;
+    public TextMeshProUGUI carnivoreMinText;
+
+    void Start()
+    {
+        if (vegetationManager != null && plantReproductionSlider != null)
+        {
+            plantReproductionSlider.minValue = 1f;
+            plantReproductionSlider.maxValue = 60f;
+            plantReproductionSlider.value = vegetationManager.reproductionInterval;
+            plantReproductionSlider.onValueChanged.AddListener(v =>
+            {
+                vegetationManager.reproductionInterval = v;
+                UpdateTexts();
+            });
+        }
+
+        if (populationBalancer != null)
+        {
+            if (herbivoreMinSlider != null)
+            {
+                herbivoreMinSlider.minValue = 0;
+                herbivoreMinSlider.maxValue = 100;
+                herbivoreMinSlider.value = populationBalancer.minHerbivores;
+                herbivoreMinSlider.onValueChanged.AddListener(v =>
+                {
+                    populationBalancer.minHerbivores = Mathf.RoundToInt(v);
+                    UpdateTexts();
+                });
+            }
+
+            if (carnivoreMinSlider != null)
+            {
+                carnivoreMinSlider.minValue = 0;
+                carnivoreMinSlider.maxValue = 100;
+                carnivoreMinSlider.value = populationBalancer.minCarnivores;
+                carnivoreMinSlider.onValueChanged.AddListener(v =>
+                {
+                    populationBalancer.minCarnivores = Mathf.RoundToInt(v);
+                    UpdateTexts();
+                });
+            }
+        }
+
+        UpdateTexts();
+    }
+
+    void UpdateTexts()
+    {
+        if (plantReproductionText != null && vegetationManager != null)
+            plantReproductionText.text = $"Reproducción plantas: {vegetationManager.reproductionInterval:0.0}s";
+
+        if (herbivoreMinText != null && populationBalancer != null)
+            herbivoreMinText.text = $"Herbívoros mínimos: {populationBalancer.minHerbivores}";
+
+        if (carnivoreMinText != null && populationBalancer != null)
+            carnivoreMinText.text = $"Carnívoros mínimos: {populationBalancer.minCarnivores}";
+    }
+}

--- a/Assets/1-Scripts/EcosystemSettingsUI.cs.meta
+++ b/Assets/1-Scripts/EcosystemSettingsUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 642606b03dc54fc8a192de9ec31a1e7c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/1-Scripts/FpsCounter.cs
+++ b/Assets/1-Scripts/FpsCounter.cs
@@ -13,6 +13,7 @@ public class FpsCounter : MonoBehaviour
     void Update()
     {
         frames++;
+        // Time.unscaledDeltaTime evita que el contador se vea afectado por la escala de tiempo
         timer += Time.unscaledDeltaTime;
         if (timer >= 1f)
         {

--- a/Assets/1-Scripts/PopulationGraph.cs
+++ b/Assets/1-Scripts/PopulationGraph.cs
@@ -12,6 +12,7 @@ public class PopulationGraph : MonoBehaviour
     public LineRenderer carnivoresLine;
     public float sampleInterval = 1f; // Tiempo entre muestras
     public float yScale = 0.1f;       // Escala vertical para las cantidades
+    public int maxSamples = 200;      // Muestras visibles en el gráfico
 
     float timer;
     int samples;
@@ -40,6 +41,18 @@ public class PopulationGraph : MonoBehaviour
         if (lr == null) return;
         Vector3 point = new Vector3(samples, value * yScale, 0f);
         list.Add(point);
+
+        if (list.Count > maxSamples)
+        {
+            list.RemoveAt(0);
+            for (int i = 0; i < list.Count; i++)
+            {
+                Vector3 p = list[i];
+                p.x -= 1f; // Desplaza las muestras para mantenerlas visibles
+                list[i] = p;
+            }
+        }
+
         lr.positionCount = list.Count;
         lr.SetPositions(list.ToArray());
     }

--- a/Assets/1-Scripts/UIManager.cs
+++ b/Assets/1-Scripts/UIManager.cs
@@ -1,0 +1,45 @@
+using UnityEngine;
+using TMPro;
+
+/// <summary>
+/// Permite ocultar/mostrar la interfaz y abrir un panel de ajustes.
+/// Los botones de la escena deben llamar a <see cref="ToggleUI"/> y
+/// <see cref="ToggleSettingsPanel"/> respectivamente.
+/// </summary>
+public class UIManager : MonoBehaviour
+{
+    [Header("Elementos de HUD")]
+    public GameObject[] uiElements; // Elementos que se ocultan
+
+    [Header("Panel de ajustes")]
+    public GameObject settingsPanel;
+
+    [Header("Botones")]
+    public TextMeshProUGUI toggleButtonText;
+
+    bool hudVisible = true;
+
+    /// <summary>
+    /// Activa o desactiva los elementos del HUD listados.
+    /// </summary>
+    public void ToggleUI()
+    {
+        hudVisible = !hudVisible;
+        for (int i = 0; i < uiElements.Length; i++)
+        {
+            if (uiElements[i] != null)
+                uiElements[i].SetActive(hudVisible);
+        }
+        if (toggleButtonText != null)
+            toggleButtonText.text = hudVisible ? "Ocultar UI" : "Mostrar UI";
+    }
+
+    /// <summary>
+    /// Muestra u oculta el panel de parámetros del ecosistema.
+    /// </summary>
+    public void ToggleSettingsPanel()
+    {
+        if (settingsPanel != null)
+            settingsPanel.SetActive(!settingsPanel.activeSelf);
+    }
+}

--- a/Assets/1-Scripts/UIManager.cs.meta
+++ b/Assets/1-Scripts/UIManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7f7095b909404d93a6f2ecc112cf64b3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Allow hiding/showing HUD and open settings panel via new UI manager
- Adjust plant reproduction and population thresholds in real time
- Limit population graph to fixed samples and clarify FPS counter time base

## Testing
- `apt-get update` *(some index files failed to download)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package dotnet-sdk-7.0)*
- `dotnet --info` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6897c2fe2df08326837bbfa40987a4d1