### PR TITLE
feat: add DOTS need-based death system

### DIFF
--- a/Assets/1-Scripts/DOTS/Systems/NeedDeathSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/NeedDeathSystem.cs
@@ -1,0 +1,22 @@
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Entities;
+
+[BurstCompile]
+public partial struct NeedDeathSystem : ISystem
+{
+    public void OnUpdate(ref SystemState state)
+    {
+        var ecb = new EntityCommandBuffer(Allocator.Temp);
+
+        foreach (var (needs, entity) in SystemAPI.Query<RefRO<Needs>>().WithEntityAccess())
+        {
+            if (needs.ValueRO.Hunger >= 1f || needs.ValueRO.Thirst >= 1f || needs.ValueRO.Sleep >= 1f)
+            {
+                ecb.DestroyEntity(entity);
+            }
+        }
+
+        ecb.Playback(state.EntityManager);
+    }
+}

--- a/Assets/1-Scripts/DOTS/Systems/NeedDeathSystem.cs.meta
+++ b/Assets/1-Scripts/DOTS/Systems/NeedDeathSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6e7a3da8ab2e4674977e8b0f7e0e715f


### PR DESCRIPTION
## Summary
- implement DOTS system that destroys entities when basic needs are maxed out

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_b_6898817543ac8326b2ee227ef25162db