### PR TITLE
Fix plant grid system query enumeration

### DIFF
--- a/Assets/1-Scripts/DOTS/Systems/PlantGridSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/PlantGridSystem.cs
@@ -24,7 +24,7 @@ public partial struct PlantGridSystem : ISystem
 
         var ecb = new EntityCommandBuffer(Allocator.Temp);
 
-        foreach (var (plant, gp) in SystemAPI.Query<RefRW<Plant>, RefRO<GridPosition>>().WithEntityAccess())
+        foreach (var (plant, gp) in SystemAPI.Query<RefRW<Plant>, RefRO<GridPosition>>())
         {
             int neighbours = 0;
             for (int dx = -1; dx <= 1; dx++)


### PR DESCRIPTION
## Summary
- remove unnecessary WithEntityAccess from PlantGridSystem query to avoid tuple deconstruction errors

## Testing
- `dotnet build` *(fails: command not found: dotnet)*
- `find . -iname '*test*'`

------
https://chatgpt.com/codex/tasks/task_b_6898915986ac83269561ebbcadd02cf7