### PR TITLE
Refine DOTS plant growth behaviour

### DIFF
--- a/Assets/1-Scripts/DOTS/Authoring/PlantManagerAuthoring.cs
+++ b/Assets/1-Scripts/DOTS/Authoring/PlantManagerAuthoring.cs
@@ -7,6 +7,8 @@ public class PlantManagerAuthoring : MonoBehaviour
 {
     public GameObject plantPrefab;
     [Range(0, 1f)] public float reproductionCost = 0.3f;
+    public int underpopulationLimit = 2;
+    public int reproductionThreshold = 3;
     public int overcrowdLimit = 5;
 
     class Baker : Baker<PlantManagerAuthoring>
@@ -18,7 +20,9 @@ public class PlantManagerAuthoring : MonoBehaviour
             {
                 Prefab = GetEntity(authoring.plantPrefab, TransformUsageFlags.Dynamic),
                 ReproductionCost = authoring.reproductionCost,
-                OvercrowdLimit = authoring.overcrowdLimit
+                UnderpopulationLimit = authoring.underpopulationLimit,
+                OvercrowdLimit = authoring.overcrowdLimit,
+                ReproductionThreshold = authoring.reproductionThreshold
             });
         }
     }
@@ -28,5 +32,7 @@ public struct PlantManager : IComponentData
 {
     public Entity Prefab;
     public float ReproductionCost;
+    public int UnderpopulationLimit;
     public int OvercrowdLimit;
+    public int ReproductionThreshold;
 }

--- a/Assets/1-Scripts/DOTS/Systems/PlantGridSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/PlantGridSystem.cs
@@ -16,6 +16,8 @@ public partial struct PlantGridSystem : ISystem
         var query = SystemAPI.QueryBuilder().WithAll<Plant, GridPosition>().Build();
         int count = query.CalculateEntityCount();
         var occupancy = new NativeParallelHashMap<int2, byte>(count, Allocator.Temp);
+        var births = new NativeParallelHashMap<int2, int>(count * 8, Allocator.Temp);
+        var prefabPlant = state.EntityManager.GetComponentData<Plant>(manager.Prefab);
 
         foreach (var gp in SystemAPI.Query<RefRO<GridPosition>>())
         {
@@ -27,6 +29,7 @@ public partial struct PlantGridSystem : ISystem
         foreach (var (plant, gp) in SystemAPI.Query<RefRW<Plant>, RefRO<GridPosition>>())
         {
             int neighbours = 0;
+            int children = 0;
             for (int dx = -1; dx <= 1; dx++)
             {
                 for (int dz = -1; dz <= 1; dz++)
@@ -34,62 +37,67 @@ public partial struct PlantGridSystem : ISystem
                     if (dx == 0 && dz == 0) continue;
                     int2 check = gp.ValueRO.Cell + new int2(dx, dz);
                     if (occupancy.ContainsKey(check))
+                    {
                         neighbours++;
+                    }
+                    else if (plant.ValueRO.Stage == PlantStage.Mature)
+                    {
+                        if (births.TryGetValue(check, out var existing))
+                        {
+                            births[check] = existing + 1;
+                        }
+                        else
+                        {
+                            births.TryAdd(check, 1);
+                        }
+                        children++;
+                    }
                 }
             }
 
-            if (neighbours > manager.OvercrowdLimit)
+            if (neighbours < manager.UnderpopulationLimit || neighbours > manager.OvercrowdLimit)
             {
                 plant.ValueRW.Stage = PlantStage.Withering;
             }
-
-            if (plant.ValueRO.Stage == PlantStage.Mature)
-            {
-                bool reproduced = false;
-                for (int dx = -1; dx <= 1; dx++)
-                {
-                    for (int dz = -1; dz <= 1; dz++)
-                    {
-                        if (dx == 0 && dz == 0) continue;
-                        int2 target = gp.ValueRO.Cell + new int2(dx, dz);
-                        if (occupancy.ContainsKey(target))
-                            continue;
-
-                        var child = ecb.Instantiate(manager.Prefab);
-                        ecb.SetComponent(child, new LocalTransform
-                        {
-                            Position = new float3(target.x, 0f, target.y),
-                            Rotation = quaternion.identity,
-                            Scale = 0.2f
-                        });
-                        ecb.SetComponent(child, new GridPosition { Cell = target });
-                        ecb.SetComponent(child, new Plant
-                        {
-                            Growth = plant.ValueRO.MaxGrowth * 0.2f,
-                            MaxGrowth = plant.ValueRO.MaxGrowth,
-                            GrowthRate = plant.ValueRO.GrowthRate,
-                            ScaleStep = 1,
-                            Stage = PlantStage.Growing
-                        });
-                        occupancy.TryAdd(target, 0);
-                        reproduced = true;
-                    }
-                }
-
-                if (reproduced)
-                {
-                    plant.ValueRW.Growth -= plant.ValueRO.MaxGrowth * manager.ReproductionCost;
-                    if (plant.ValueRW.Growth < 0f) plant.ValueRW.Growth = 0f;
-                    plant.ValueRW.Stage = PlantStage.Growing;
-                }
-            }
-            else if (plant.ValueRO.Stage == PlantStage.Withering && neighbours <= manager.OvercrowdLimit)
+            else if (plant.ValueRO.Stage == PlantStage.Withering)
             {
                 plant.ValueRW.Stage = PlantStage.Growing;
+            }
+
+            if (children > 0)
+            {
+                plant.ValueRW.Growth -= plant.ValueRO.MaxGrowth * manager.ReproductionCost * children;
+                if (plant.ValueRW.Growth < 0f) plant.ValueRW.Growth = 0f;
+                plant.ValueRW.Stage = PlantStage.Growing;
+            }
+        }
+
+        foreach (var kvp in births)
+        {
+            if (kvp.Value >= manager.ReproductionThreshold && !occupancy.ContainsKey(kvp.Key))
+            {
+                var child = ecb.Instantiate(manager.Prefab);
+                ecb.SetComponent(child, new LocalTransform
+                {
+                    Position = new float3(kvp.Key.x, 0f, kvp.Key.y),
+                    Rotation = quaternion.identity,
+                    Scale = 0.2f
+                });
+                ecb.SetComponent(child, new GridPosition { Cell = kvp.Key });
+                ecb.SetComponent(child, new Plant
+                {
+                    Growth = prefabPlant.MaxGrowth * 0.2f,
+                    MaxGrowth = prefabPlant.MaxGrowth,
+                    GrowthRate = prefabPlant.GrowthRate,
+                    ScaleStep = 1,
+                    Stage = PlantStage.Growing
+                });
+                occupancy.TryAdd(kvp.Key, 0);
             }
         }
 
         ecb.Playback(state.EntityManager);
         occupancy.Dispose();
+        births.Dispose();
     }
 }

--- a/Assets/2-Art/1-3D/DOTS/PlantManager.prefab
+++ b/Assets/2-Art/1-3D/DOTS/PlantManager.prefab
@@ -46,4 +46,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   plantPrefab: {fileID: 8311962731384735518, guid: 7bdfa0a76e3956b4eafd27fcefa04ecc, type: 3}
   reproductionCost: 0.3
+  underpopulationLimit: 2
+  reproductionThreshold: 3
   overcrowdLimit: 5


### PR DESCRIPTION
## Summary
- Allow configuration of underpopulation and reproduction thresholds for plants
- Rework grid simulation to apply Game-of-Life-style birth and death rules
- Expose new parameters in PlantManager prefab
- Use TryGetValue/TryAdd to update birth counts and fix compilation error

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689895d0e6e8832691ef3e712f59530c