### PR TITLE
Add density-controlled DOTS plant propagation

### DIFF
--- a/Assets/1-Scripts/DOTS/Authoring/PlantManagerAuthoring.cs
+++ b/Assets/1-Scripts/DOTS/Authoring/PlantManagerAuthoring.cs
@@ -6,8 +6,9 @@ using UnityEngine;
 public class PlantManagerAuthoring : MonoBehaviour
 {
     public GameObject plantPrefab;
-    [Range(0, 1f)] public float reproductionCost = 0.3f;
-    public int overcrowdLimit = 5;
+    [Range(0f, 1f)] public float density = 0.5f;
+    public bool enforceDensity = true;
+    public int maxPlants = 1000;
 
     class Baker : Baker<PlantManagerAuthoring>
     {
@@ -17,8 +18,9 @@ public class PlantManagerAuthoring : MonoBehaviour
             AddComponent(entity, new PlantManager
             {
                 Prefab = GetEntity(authoring.plantPrefab, TransformUsageFlags.Dynamic),
-                ReproductionCost = authoring.reproductionCost,
-                OvercrowdLimit = authoring.overcrowdLimit
+                Density = authoring.density,
+                EnforceDensity = authoring.enforceDensity,
+                MaxPlants = authoring.maxPlants
             });
         }
     }
@@ -27,6 +29,7 @@ public class PlantManagerAuthoring : MonoBehaviour
 public struct PlantManager : IComponentData
 {
     public Entity Prefab;
-    public float ReproductionCost;
-    public int OvercrowdLimit;
+    public float Density;
+    public bool EnforceDensity;
+    public int MaxPlants;
 }

--- a/Assets/2-Art/1-3D/DOTS/PlantManager.prefab
+++ b/Assets/2-Art/1-3D/DOTS/PlantManager.prefab
@@ -45,5 +45,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   plantPrefab: {fileID: 8311962731384735518, guid: 7bdfa0a76e3956b4eafd27fcefa04ecc, type: 3}
-  reproductionCost: 0.3
-  overcrowdLimit: 5
+  density: 0.5
+  enforceDensity: 1
+  maxPlants: 1000


### PR DESCRIPTION
## Summary
- Simplify plant manager to a single density parameter and max plant limit
- Regrow and cull plants based on density while avoiding cell conflicts
- Expose new density settings in PlantManager prefab

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689895d0e6e8832691ef3e712f59530c