### PR TITLE
Enable mature plant reproduction across grid

### DIFF
--- a/Assets/1-Scripts/DOTS/Authoring/PlantManagerAuthoring.cs
+++ b/Assets/1-Scripts/DOTS/Authoring/PlantManagerAuthoring.cs
@@ -9,6 +9,7 @@ public class PlantManagerAuthoring : MonoBehaviour
     [Range(0f, 1f)] public float density = 0.5f;
     public bool enforceDensity = true;
     public int maxPlants = 1000;
+    public int reproductionThreshold = 4;
 
     class Baker : Baker<PlantManagerAuthoring>
     {
@@ -20,7 +21,8 @@ public class PlantManagerAuthoring : MonoBehaviour
                 Prefab = GetEntity(authoring.plantPrefab, TransformUsageFlags.Dynamic),
                 Density = authoring.density,
                 EnforceDensity = authoring.enforceDensity,
-                MaxPlants = authoring.maxPlants
+                MaxPlants = authoring.maxPlants,
+                ReproductionThreshold = authoring.reproductionThreshold
             });
         }
     }
@@ -32,4 +34,5 @@ public struct PlantManager : IComponentData
     public float Density;
     public bool EnforceDensity;
     public int MaxPlants;
+    public int ReproductionThreshold;
 }

--- a/Assets/1-Scripts/DOTS/Systems/PlantGridSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/PlantGridSystem.cs
@@ -15,29 +15,31 @@ public partial struct PlantGridSystem : ISystem
 
         var query = SystemAPI.QueryBuilder().WithAll<Plant, GridPosition>().Build();
         int current = query.CalculateEntityCount();
-        var occupancy = new NativeParallelHashSet<int2>(current, Allocator.Temp);
+        int limit = manager.EnforceDensity
+            ? (int)math.round(manager.Density * manager.MaxPlants)
+            : manager.MaxPlants;
+        // Reserve capacity up to the population limit so new births fit without errors
+        var occupancy = new NativeParallelHashSet<int2>(limit, Allocator.Temp);
 
         foreach (var gp in SystemAPI.Query<RefRO<GridPosition>>())
         {
             occupancy.Add(gp.ValueRO.Cell);
         }
 
-        int target = manager.EnforceDensity ? (int)math.round(manager.Density * manager.MaxPlants) : int.MaxValue;
-        int neededBirths = math.max(0, target - current);
-        int neededDeaths = math.max(0, current - target);
+        // limit computed earlier
 
         var ecb = new EntityCommandBuffer(Allocator.Temp);
         var prefabPlant = state.EntityManager.GetComponentData<Plant>(manager.Prefab);
-
-        if (neededBirths > 0)
+        int births = 0;
+        if (current < limit)
         {
             foreach (var (plant, gp) in SystemAPI.Query<RefRO<Plant>, RefRO<GridPosition>>())
             {
-                if (plant.ValueRO.Stage != PlantStage.Mature)
+                if (plant.ValueRO.Stage != PlantStage.Mature || current >= limit || births >= manager.ReproductionThreshold)
                     continue;
 
                 var rnd = Unity.Mathematics.Random.CreateFromIndex((uint)math.hash(gp.ValueRO.Cell));
-                for (int i = 0; i < 8 && neededBirths > 0; i++)
+                for (int i = 0; i < 8; i++)
                 {
                     int2 offset;
                     do
@@ -56,7 +58,8 @@ public partial struct PlantGridSystem : ISystem
                             Rotation = quaternion.identity,
                             Scale = 0.2f
                         });
-                        ecb.SetComponent(child, new GridPosition { Cell = cell });
+                        // Newly spawned plants need a GridPosition component
+                        ecb.AddComponent(child, new GridPosition { Cell = cell });
                         ecb.SetComponent(child, new Plant
                         {
                             Growth = prefabPlant.MaxGrowth * 0.2f,
@@ -65,52 +68,25 @@ public partial struct PlantGridSystem : ISystem
                             ScaleStep = 1,
                             Stage = PlantStage.Growing
                         });
-                        neededBirths--;
+                        current++;
+                        births++;
                         break;
                     }
                 }
-
-                if (neededBirths == 0)
-                    break;
             }
         }
 
-        if (neededDeaths > 0)
+        if (current > limit)
         {
             var entities = query.ToEntityArray(Allocator.Temp);
-            for (int i = 0; i < neededDeaths && i < entities.Length; i++)
+            for (int i = 0; i < current - limit && i < entities.Length; i++)
             {
                 ecb.DestroyEntity(entities[i]);
             }
             entities.Dispose();
         }
 
-        foreach (var kvp in births)
-        {
-            if (kvp.Value >= manager.ReproductionThreshold && !occupancy.ContainsKey(kvp.Key))
-            {
-                var child = ecb.Instantiate(manager.Prefab);
-                ecb.SetComponent(child, new LocalTransform
-                {
-                    Position = new float3(kvp.Key.x, 0f, kvp.Key.y),
-                    Rotation = quaternion.identity,
-                    Scale = 0.2f
-                });
-                ecb.SetComponent(child, new GridPosition { Cell = kvp.Key });
-                ecb.SetComponent(child, new Plant
-                {
-                    Growth = prefabPlant.MaxGrowth * 0.2f,
-                    MaxGrowth = prefabPlant.MaxGrowth,
-                    GrowthRate = prefabPlant.GrowthRate,
-                    ScaleStep = 1,
-                    Stage = PlantStage.Growing
-                });
-                occupancy.TryAdd(kvp.Key, 0);
-            }
-        }
-
         ecb.Playback(state.EntityManager);
         occupancy.Dispose();
-        births.Dispose();
     }
 }


### PR DESCRIPTION
## Summary
- reserve occupancy hash set capacity for full population limit
- add `GridPosition` component when instantiating new plants to avoid component store errors

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_b_6898a559ffa083268be93ceeed80a30a