### PR TITLE
Add DOTS herbivore system and configurable plant reproduction

### DIFF
--- a/Assets/1-Scripts/DOTS/Authoring/HerbivoreAuthoring.cs
+++ b/Assets/1-Scripts/DOTS/Authoring/HerbivoreAuthoring.cs
@@ -1,0 +1,58 @@
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Rendering;
+using Unity.Transforms;
+using UnityEngine;
+
+/// Authoring for DOTS herbivore prefab.
+public class HerbivoreAuthoring : MonoBehaviour
+{
+    [Header("Stats")]
+    public float maxHealth = 50f;
+    public float maxHunger = 100f;
+    public float moveSpeed = 2f;
+    public float idleHungerRate = 1f;
+    public float moveHungerRate = 2f;
+    public float hungerGainOnEat = 40f;
+    [Range(0f,1f)] public float healthRestorePercent = 0.25f;
+    public float changeDirectionInterval = 2f;
+
+    class Baker : Baker<HerbivoreAuthoring>
+    {
+        public override void Bake(HerbivoreAuthoring authoring)
+        {
+            var entity = GetEntity(TransformUsageFlags.Dynamic);
+
+            AddComponent(entity, new Herbivore
+            {
+                MoveSpeed = authoring.moveSpeed,
+                IdleHungerRate = authoring.idleHungerRate,
+                MoveHungerRate = authoring.moveHungerRate,
+                HungerGain = authoring.hungerGainOnEat,
+                HealthRestorePercent = authoring.healthRestorePercent,
+                ChangeDirectionInterval = authoring.changeDirectionInterval,
+                DirectionTimer = 0f,
+                MoveDirection = float3.zero
+            });
+
+            AddComponent(entity, new Health
+            {
+                Value = authoring.maxHealth,
+                Max = authoring.maxHealth
+            });
+
+            AddComponent(entity, new Hunger
+            {
+                Value = authoring.maxHunger,
+                Max = authoring.maxHunger,
+                DecreaseRate = 0f,
+                SeekThreshold = 0f,
+                DeathThreshold = 0f
+            });
+
+            AddComponent(entity, LocalTransform.FromPositionRotationScale(float3.zero, quaternion.identity, 1f));
+            AddComponent<HerbivoreTag>(entity);
+            AddComponent(entity, new URPMaterialPropertyBaseColor { Value = new float4(0f, 1f, 0f, 1f) });
+        }
+    }
+}

--- a/Assets/1-Scripts/DOTS/Authoring/HerbivoreAuthoring.cs.meta
+++ b/Assets/1-Scripts/DOTS/Authoring/HerbivoreAuthoring.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7431100e9df74fbfbd478386084912f1

--- a/Assets/1-Scripts/DOTS/Authoring/HerbivoreManagerAuthoring.cs
+++ b/Assets/1-Scripts/DOTS/Authoring/HerbivoreManagerAuthoring.cs
@@ -1,0 +1,30 @@
+using Unity.Entities;
+using UnityEngine;
+
+/// Authoring that configures spawning of DOTS herbivores.
+public class HerbivoreManagerAuthoring : MonoBehaviour
+{
+    public GameObject herbivorePrefab;
+    public int initialCount = 20;
+
+    class Baker : Baker<HerbivoreManagerAuthoring>
+    {
+        public override void Bake(HerbivoreManagerAuthoring authoring)
+        {
+            var entity = GetEntity(TransformUsageFlags.None);
+            AddComponent(entity, new HerbivoreManager
+            {
+                Prefab = GetEntity(authoring.herbivorePrefab, TransformUsageFlags.Dynamic),
+                InitialCount = authoring.initialCount,
+                Initialized = 0
+            });
+        }
+    }
+}
+
+public struct HerbivoreManager : IComponentData
+{
+    public Entity Prefab;
+    public int InitialCount;
+    public byte Initialized;
+}

--- a/Assets/1-Scripts/DOTS/Authoring/HerbivoreManagerAuthoring.cs.meta
+++ b/Assets/1-Scripts/DOTS/Authoring/HerbivoreManagerAuthoring.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 924f9cd669f6482abccb28eb19121742

--- a/Assets/1-Scripts/DOTS/Authoring/PlantManagerAuthoring.cs
+++ b/Assets/1-Scripts/DOTS/Authoring/PlantManagerAuthoring.cs
@@ -15,6 +15,8 @@ public class PlantManagerAuthoring : MonoBehaviour
     [Header("Reproduction")]
     [Range(0f,1f)]
     public float reproductionCost = 0.2f;
+    [Range(1,8)]
+    public int reproductionCount = 1;
 
     class Baker : Baker<PlantManagerAuthoring>
     {
@@ -28,6 +30,7 @@ public class PlantManagerAuthoring : MonoBehaviour
                 PatchCount = authoring.patchCount,
                 PatchRadius = authoring.patchRadius,
                 ReproductionCost = authoring.reproductionCost,
+                ReproductionCount = (byte)math.clamp(authoring.reproductionCount, 1, 8),
                 Initialized = 0
             });
         }
@@ -41,5 +44,6 @@ public struct PlantManager : IComponentData
     public int PatchCount;
     public float PatchRadius;
     public float ReproductionCost;
+    public byte ReproductionCount;
     public byte Initialized;
 }

--- a/Assets/1-Scripts/DOTS/Components/Herbivore.cs
+++ b/Assets/1-Scripts/DOTS/Components/Herbivore.cs
@@ -1,0 +1,17 @@
+using Unity.Entities;
+using Unity.Mathematics;
+
+/// <summary>
+/// Basic data for a DOTS herbivore.
+/// </summary>
+public struct Herbivore : IComponentData
+{
+    public float MoveSpeed;             // Movement speed per second
+    public float IdleHungerRate;        // Hunger loss per second when idle
+    public float MoveHungerRate;        // Additional hunger loss per speed unit
+    public float HungerGain;            // Hunger gained when eating a plant
+    public float HealthRestorePercent;  // Percent of max health restored when eating (0-1)
+    public float ChangeDirectionInterval; // Seconds between direction changes
+    public float DirectionTimer;        // Time until next random direction change
+    public float3 MoveDirection;        // Current normalized movement direction
+}

--- a/Assets/1-Scripts/DOTS/Components/Herbivore.cs.meta
+++ b/Assets/1-Scripts/DOTS/Components/Herbivore.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 75f4c94225bd43bba00a57445f44cf18

--- a/Assets/1-Scripts/DOTS/Systems/HerbivoreSpawnerSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/HerbivoreSpawnerSystem.cs
@@ -1,0 +1,46 @@
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+/// Spawns the initial herbivores as configured by HerbivoreManager.
+[BurstCompile]
+public partial struct HerbivoreSpawnerSystem : ISystem
+{
+    public void OnUpdate(ref SystemState state)
+    {
+        if (!SystemAPI.TryGetSingletonRW<HerbivoreManager>(out var managerRw) ||
+            !SystemAPI.TryGetSingleton<GridManager>(out var grid))
+            return;
+
+        if (managerRw.ValueRO.Initialized != 0)
+            return;
+
+        var manager = managerRw.ValueRO;
+        var ecb = new EntityCommandBuffer(Allocator.Temp);
+        var rand = Unity.Mathematics.Random.CreateFromIndex(3);
+
+        float2 area = grid.AreaSize;
+        int2 half = (int2)(area / 2f);
+        for (int i = 0; i < manager.InitialCount; i++)
+        {
+            int2 cell = new int2(
+                rand.NextInt(-half.x, half.x + 1),
+                rand.NextInt(-half.y, half.y + 1));
+
+            var e = ecb.Instantiate(manager.Prefab);
+            ecb.SetComponent(e, new LocalTransform
+            {
+                Position = new float3(cell.x, 0f, cell.y),
+                Rotation = quaternion.identity,
+                Scale = 1f
+            });
+            ecb.AddComponent(e, new GridPosition { Cell = cell });
+        }
+
+        manager.Initialized = 1;
+        managerRw.ValueRW = manager;
+        ecb.Playback(state.EntityManager);
+    }
+}

--- a/Assets/1-Scripts/DOTS/Systems/HerbivoreSpawnerSystem.cs.meta
+++ b/Assets/1-Scripts/DOTS/Systems/HerbivoreSpawnerSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ff0faf9a77094cb790a6e71ef19b9609

--- a/Assets/1-Scripts/DOTS/Systems/HerbivoreSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/HerbivoreSystem.cs
@@ -1,0 +1,86 @@
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+/// Handles movement, hunger and eating for DOTS herbivores.
+[BurstCompile]
+public partial struct HerbivoreSystem : ISystem
+{
+    public void OnUpdate(ref SystemState state)
+    {
+        if (!SystemAPI.TryGetSingleton<GridManager>(out var grid))
+            return;
+
+        float dt = SystemAPI.Time.DeltaTime;
+        var rand = Unity.Mathematics.Random.CreateFromIndex((uint)(SystemAPI.Time.ElapsedTime * 1000 + 5));
+        float2 half = grid.AreaSize * 0.5f;
+
+        var ecb = new EntityCommandBuffer(Allocator.Temp);
+
+        // Map of plants by cell
+        var plants = new NativeParallelMultiHashMap<int2, Entity>(1024, Allocator.Temp);
+        foreach (var (pgp, pEntity) in SystemAPI.Query<RefRO<GridPosition>>().WithAll<Plant>().WithEntityAccess())
+            plants.Add(pgp.ValueRO.Cell, pEntity);
+
+        int2[] dirs = new int2[8]
+        {
+            new int2(1,0), new int2(-1,0), new int2(0,1), new int2(0,-1),
+            new int2(1,1), new int2(1,-1), new int2(-1,1), new int2(-1,-1)
+        };
+
+        foreach (var (transform, hunger, health, herb, entity) in
+                 SystemAPI.Query<RefRW<LocalTransform>, RefRW<Hunger>, RefRW<Health>, RefRW<Herbivore>>().WithEntityAccess())
+        {
+            herb.ValueRW.DirectionTimer -= dt;
+            if (herb.ValueRO.DirectionTimer <= 0f)
+            {
+                int choice = rand.NextInt(9); // 0 = idle
+                if (choice == 0)
+                    herb.ValueRW.MoveDirection = float3.zero;
+                else
+                {
+                    int2 d = dirs[choice - 1];
+                    herb.ValueRW.MoveDirection = math.normalize(new float3(d.x, 0f, d.y));
+                }
+                herb.ValueRW.DirectionTimer = herb.ValueRO.ChangeDirectionInterval;
+            }
+
+            float3 move = herb.ValueRO.MoveDirection * herb.ValueRO.MoveSpeed * dt;
+            transform.ValueRW.Position += move;
+            transform.ValueRW.Position.x = math.clamp(transform.ValueRO.Position.x, -half.x, half.x);
+            transform.ValueRW.Position.z = math.clamp(transform.ValueRO.Position.z, -half.y, half.y);
+
+            int2 cell = new int2(
+                (int)math.floor(transform.ValueRO.Position.x / grid.CellSize),
+                (int)math.floor(transform.ValueRO.Position.z / grid.CellSize));
+
+            float hungerRate = herb.ValueRO.MoveDirection.x == 0f && herb.ValueRO.MoveDirection.z == 0f
+                ? herb.ValueRO.IdleHungerRate
+                : herb.ValueRO.IdleHungerRate + herb.ValueRO.MoveHungerRate * herb.ValueRO.MoveSpeed;
+            hunger.ValueRW.Value -= hungerRate * dt;
+
+            if (hunger.ValueRO.Value <= 0f)
+            {
+                health.ValueRW.Value -= dt;
+                if (health.ValueRO.Value <= 0f)
+                {
+                    ecb.DestroyEntity(entity);
+                    continue;
+                }
+            }
+
+            if (plants.TryGetFirstValue(cell, out var plantEntity, out _))
+            {
+                hunger.ValueRW.Value = math.min(hunger.ValueRO.Max, hunger.ValueRO.Value + herb.ValueRO.HungerGain);
+                health.ValueRW.Value = math.min(health.ValueRO.Max,
+                    health.ValueRO.Value + health.ValueRO.Max * herb.ValueRO.HealthRestorePercent);
+                ecb.DestroyEntity(plantEntity);
+            }
+        }
+
+        ecb.Playback(state.EntityManager);
+        plants.Dispose();
+    }
+}

--- a/Assets/1-Scripts/DOTS/Systems/HerbivoreSystem.cs.meta
+++ b/Assets/1-Scripts/DOTS/Systems/HerbivoreSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5758536c1eff417cb71110da21a612d2


### PR DESCRIPTION
## Summary
- allow configuring how many adjacent cells plants can reproduce into (1-8)
- return mature plants to growing state after reproduction
- add DOTS herbivore prefab and manager
- spawn herbivores on the grid and drive movement, hunger and plant eating

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_b_689923b77b848326a2566305080acdcc