### PR TITLE
Refactor herbivore movement and add visual cue manager

### DIFF
--- a/Assets/1-Scripts/DOTS/Authoring/HerbivoreAuthoring.cs
+++ b/Assets/1-Scripts/DOTS/Authoring/HerbivoreAuthoring.cs
@@ -66,13 +66,14 @@ public class HerbivoreAuthoring : MonoBehaviour
             {
                 Value = authoring.maxHunger,
                 Max = authoring.maxHunger,
-                DecreaseRate = 0f,
-                SeekThreshold = 0f,
+                DecreaseRate = authoring.idleHungerRate,
+                SeekThreshold = authoring.maxHunger * 0.5f,
                 DeathThreshold = 0f
             });
 
-            // Transform inicial del herbívoro.
+            // Transform y posición inicial del herbívoro.
             AddComponent(entity, LocalTransform.FromPositionRotationScale(float3.zero, quaternion.identity, 1f));
+            AddComponent(entity, new GridPosition { Cell = int2.zero });
 
             // Etiqueta y color inicial.
 

--- a/Assets/1-Scripts/DOTS/Authoring/VisualCueManagerAuthoring.cs
+++ b/Assets/1-Scripts/DOTS/Authoring/VisualCueManagerAuthoring.cs
@@ -1,0 +1,45 @@
+using Unity.Entities;
+using Unity.Mathematics;
+using UnityEngine;
+
+/// Configura los colores utilizados para representar los estados de las entidades.
+public class VisualCueManagerAuthoring : MonoBehaviour
+{
+    [Header("Plantas")]
+    public Color plantGrowingColor = Color.yellow;
+    public Color plantMatureColor = Color.green;
+    public Color plantWitheringColor = Color.red;
+
+    [Header("Herbívoros")]
+    public Color herbivoreNormalColor = Color.green;
+    public Color herbivoreHungryColor = Color.yellow;
+    public Color herbivoreStarvingColor = Color.red;
+
+    class Baker : Baker<VisualCueManagerAuthoring>
+    {
+        public override void Bake(VisualCueManagerAuthoring authoring)
+        {
+            var entity = GetEntity(TransformUsageFlags.None);
+            AddComponent(entity, new VisualCueManager
+            {
+                PlantGrowingColor = new float4(authoring.plantGrowingColor.r, authoring.plantGrowingColor.g, authoring.plantGrowingColor.b, authoring.plantGrowingColor.a),
+                PlantMatureColor = new float4(authoring.plantMatureColor.r, authoring.plantMatureColor.g, authoring.plantMatureColor.b, authoring.plantMatureColor.a),
+                PlantWitheringColor = new float4(authoring.plantWitheringColor.r, authoring.plantWitheringColor.g, authoring.plantWitheringColor.b, authoring.plantWitheringColor.a),
+                HerbivoreNormalColor = new float4(authoring.herbivoreNormalColor.r, authoring.herbivoreNormalColor.g, authoring.herbivoreNormalColor.b, authoring.herbivoreNormalColor.a),
+                HerbivoreHungryColor = new float4(authoring.herbivoreHungryColor.r, authoring.herbivoreHungryColor.g, authoring.herbivoreHungryColor.b, authoring.herbivoreHungryColor.a),
+                HerbivoreStarvingColor = new float4(authoring.herbivoreStarvingColor.r, authoring.herbivoreStarvingColor.g, authoring.herbivoreStarvingColor.b, authoring.herbivoreStarvingColor.a)
+            });
+        }
+    }
+}
+
+/// Datos de colores globales para las visualizaciones.
+public struct VisualCueManager : IComponentData
+{
+    public float4 PlantGrowingColor;
+    public float4 PlantMatureColor;
+    public float4 PlantWitheringColor;
+    public float4 HerbivoreNormalColor;
+    public float4 HerbivoreHungryColor;
+    public float4 HerbivoreStarvingColor;
+}

--- a/Assets/1-Scripts/DOTS/Authoring/VisualCueManagerAuthoring.cs.meta
+++ b/Assets/1-Scripts/DOTS/Authoring/VisualCueManagerAuthoring.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2ed07b5f25a54d368da9db46fa62b29c

--- a/Assets/1-Scripts/DOTS/Systems/HerbivoreColorSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/HerbivoreColorSystem.cs
@@ -1,0 +1,28 @@
+using Unity.Burst;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Rendering;
+
+/// Cambia el color de los herbívoros según su nivel de hambre.
+[BurstCompile]
+public partial struct HerbivoreColorSystem : ISystem
+{
+    public void OnUpdate(ref SystemState state)
+    {
+        if (!SystemAPI.TryGetSingleton<VisualCueManager>(out var cues))
+            return;
+
+        foreach (var (hunger, color) in SystemAPI.Query<RefRO<Hunger>, RefRW<URPMaterialPropertyBaseColor>>())
+        {
+            float4 c;
+            if (hunger.ValueRO.Value <= hunger.ValueRO.SeekThreshold * 0.5f)
+                c = cues.HerbivoreStarvingColor;
+            else if (hunger.ValueRO.Value <= hunger.ValueRO.SeekThreshold)
+                c = cues.HerbivoreHungryColor;
+            else
+                c = cues.HerbivoreNormalColor;
+
+            color.ValueRW.Value = c;
+        }
+    }
+}

--- a/Assets/1-Scripts/DOTS/Systems/HerbivoreColorSystem.cs.meta
+++ b/Assets/1-Scripts/DOTS/Systems/HerbivoreColorSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8fd1f6ad3c3d4cb0ac81d8d6ff67d8bf

--- a/Assets/1-Scripts/DOTS/Systems/HerbivoreSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/HerbivoreSystem.cs
@@ -6,6 +6,9 @@ using Unity.Transforms;
 
 
 /// Gestiona el movimiento, hambre y alimentación de los herbívoros DOTS.
+/// TODO: Implementar reproducción agregando un componente de reproducción con umbrales
+/// y cooldown, buscando parejas cercanas, acercando a ambos hasta una distancia de
+/// apareamiento y generando nuevas entidades de cría al cumplirse las condiciones.
 [BurstCompile]
 public partial struct HerbivoreSystem : ISystem
 {
@@ -21,43 +24,76 @@ public partial struct HerbivoreSystem : ISystem
 
         var ecb = new EntityCommandBuffer(Allocator.Temp);
 
-        // Mapa de plantas por celda para poder consumirlas.
+        // Mapa de plantas por celda para poder consumirlas y lista para búsqueda.
         var plants = new NativeParallelMultiHashMap<int2, Entity>(1024, Allocator.Temp);
+        var plantCells = new NativeList<int2>(Allocator.Temp);
         foreach (var (pgp, pEntity) in SystemAPI.Query<RefRO<GridPosition>>().WithAll<Plant>().WithEntityAccess())
-            plants.Add(pgp.ValueRO.Cell, pEntity);
-
-        // Direcciones posibles (8 vecinos).
-        int2[] dirs = new int2[8]
         {
-            new int2(1,0), new int2(-1,0), new int2(0,1), new int2(0,-1),
-            new int2(1,1), new int2(1,-1), new int2(-1,1), new int2(-1,-1)
+            plants.Add(pgp.ValueRO.Cell, pEntity);
+            plantCells.Add(pgp.ValueRO.Cell);
+        }
+
+        // Direcciones posibles (4 vecinos cardinales).
+        int2[] dirs = new int2[4]
+        {
+            new int2(1,0), new int2(-1,0), new int2(0,1), new int2(0,-1)
         };
 
         // Recorremos cada herbívoro.
         foreach (var (transform, hunger, health, herb, entity) in
                  SystemAPI.Query<RefRW<LocalTransform>, RefRW<Hunger>, RefRW<Health>, RefRW<Herbivore>>().WithEntityAccess())
         {
-            // Contador para cambiar de dirección aleatoriamente.
-            herb.ValueRW.DirectionTimer -= dt;
-            if (herb.ValueRO.DirectionTimer <= 0f)
+            // Determinar si tiene hambre para correr hacia plantas.
+            bool isHungry = hunger.ValueRO.Value <= hunger.ValueRO.SeekThreshold;
+
+            // Selección de dirección: si tiene hambre busca la planta más cercana.
+            if (isHungry && plantCells.Length > 0)
             {
-                int choice = rand.NextInt(9); // 0 = quieto
-                if (choice == 0)
-                    herb.ValueRW.MoveDirection = float3.zero;
-                else
+                int2 currentCell = new int2(
+                    (int)math.floor(transform.ValueRO.Position.x / grid.CellSize),
+                    (int)math.floor(transform.ValueRO.Position.z / grid.CellSize));
+                float bestDist = float.MaxValue;
+                int2 target = currentCell;
+                for (int i = 0; i < plantCells.Length; i++)
                 {
-                    int2 d = dirs[choice - 1];
-                    herb.ValueRW.MoveDirection = math.normalize(new float3(d.x, 0f, d.y));
+                    float dist = math.lengthsq((float2)(plantCells[i] - currentCell));
+                    if (dist < bestDist)
+                    {
+                        bestDist = dist;
+                        target = plantCells[i];
+                    }
                 }
-                herb.ValueRW.DirectionTimer = herb.ValueRO.ChangeDirectionInterval;
+                float3 targetPos = new float3(target.x * grid.CellSize, 0f, target.y * grid.CellSize);
+                herb.ValueRW.MoveDirection = math.normalize(targetPos - transform.ValueRO.Position);
+            }
+            else
+            {
+                // Contador para cambiar de dirección aleatoriamente.
+                herb.ValueRW.DirectionTimer -= dt;
+                if (herb.ValueRO.DirectionTimer <= 0f)
+                {
+                    int choice = rand.NextInt(5); // 0 = quieto
+                    if (choice == 0)
+                        herb.ValueRW.MoveDirection = float3.zero;
+                    else
+                    {
+                        int2 d = dirs[choice - 1];
+                        herb.ValueRW.MoveDirection = math.normalize(new float3(d.x, 0f, d.y));
+                    }
+                    herb.ValueRW.DirectionTimer = herb.ValueRO.ChangeDirectionInterval;
+                }
             }
 
-            // Calculamos el desplazamiento y lo limitamos dentro del área.
-            float3 move = herb.ValueRO.MoveDirection * herb.ValueRO.MoveSpeed * dt;
-            transform.ValueRW.Position += move;
-            transform.ValueRW.Position.x = math.clamp(transform.ValueRO.Position.x, -half.x, half.x);
-            transform.ValueRW.Position.z = math.clamp(transform.ValueRO.Position.z, -half.y, half.y);
-            
+            // Calculamos el desplazamiento y lo limitamos dentro del área y celdas.
+            float speed = isHungry ? herb.ValueRO.MoveSpeed * 2f : herb.ValueRO.MoveSpeed;
+            float3 move = herb.ValueRO.MoveDirection * speed * dt;
+            float3 pos = transform.ValueRO.Position + move;
+            pos.x = math.clamp(pos.x, -half.x, half.x);
+            pos.z = math.clamp(pos.z, -half.y, half.y);
+            pos.x = math.round(pos.x / grid.CellSize) * grid.CellSize;
+            pos.z = math.round(pos.z / grid.CellSize) * grid.CellSize;
+            transform.ValueRW.Position = pos;
+
             // Celda en la que se encuentra actualmente.
             int2 cell = new int2(
                 (int)math.floor(transform.ValueRO.Position.x / grid.CellSize),
@@ -66,7 +102,7 @@ public partial struct HerbivoreSystem : ISystem
             // Consumo de hambre según si se mueve o no.
             float hungerRate = herb.ValueRO.MoveDirection.x == 0f && herb.ValueRO.MoveDirection.z == 0f
                 ? herb.ValueRO.IdleHungerRate
-                : herb.ValueRO.IdleHungerRate + herb.ValueRO.MoveHungerRate * herb.ValueRO.MoveSpeed;
+                : herb.ValueRO.IdleHungerRate + herb.ValueRO.MoveHungerRate * speed;
             hunger.ValueRW.Value -= hungerRate * dt;
 
             // Si el hambre llega a 0 empezamos a perder vida.
@@ -92,5 +128,6 @@ public partial struct HerbivoreSystem : ISystem
         // Ejecutamos los cambios y liberamos la memoria usada.
         ecb.Playback(state.EntityManager);
         plants.Dispose();
+        plantCells.Dispose();
     }
 }

--- a/Assets/1-Scripts/DOTS/Systems/PlantColorSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/PlantColorSystem.cs
@@ -9,19 +9,22 @@ public partial struct PlantColorSystem : ISystem
 {
     public void OnUpdate(ref SystemState state)
     {
+        if (!SystemAPI.TryGetSingleton<VisualCueManager>(out var cues))
+            return;
+
         foreach (var (plant, color) in SystemAPI.Query<RefRO<Plant>, RefRW<URPMaterialPropertyBaseColor>>())
         {
             float4 c = color.ValueRO.Value;
             switch (plant.ValueRO.Stage)
             {
                 case PlantStage.Growing:
-                    c = new float4(1f, 1f, 0f, 1f); // Amarillo
+                    c = cues.PlantGrowingColor;
                     break;
                 case PlantStage.Mature:
-                    c = new float4(0f, 1f, 0f, 1f); // Verde
+                    c = cues.PlantMatureColor;
                     break;
                 case PlantStage.Withering:
-                    c = new float4(1f, 0f, 0f, 1f); // Rojo
+                    c = cues.PlantWitheringColor;
                     break;
             }
 


### PR DESCRIPTION
## Summary
- Snap herbivore movement to grid, run faster when hungry and seek nearest plant
- Centralize visualization colors via new VisualCueManager authoring and systems
- Color herbivores based on hunger and plants by growth stage
- Document reproduction approach for herbivores with a TODO comment

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a4b11b6a483268ecd4836df39062f