### PR TITLE
Improve herbivore movement and plant consumption

### DIFF
--- a/Assets/1-Scripts/DOTS/Systems/PlantGrowthSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/PlantGrowthSystem.cs
@@ -28,8 +28,7 @@ public partial struct PlantGrowthSystem : ISystem
                     }
                     break;
                 case PlantStage.Withering:
-                    // Reduce el tamaño hasta desaparecer.
-                    plant.ValueRW.Growth -= plant.ValueRO.GrowthRate * dt;
+                    // La reducción de tamaño ocurre al ser consumida por herbívoros.
                     if (plant.ValueRO.Growth <= 0f)
                     {
                         ecb.DestroyEntity(entity);


### PR DESCRIPTION
## Summary
- prevent herbivores from snapping to grid and rotate them toward their movement direction
- consume plants in front of herbivores, gradually restoring hunger and withering plants
- delegate plant withering to herbivore consumption logic

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_b_689a68ae23e48326b0c5738d7518c53a