### PR TITLE
Enhance herbivore behaviour and reproduction

### DIFF
--- a/Assets/1-Scripts/DOTS/Authoring/HerbivoreAuthoring.cs
+++ b/Assets/1-Scripts/DOTS/Authoring/HerbivoreAuthoring.cs
@@ -1,3 +1,4 @@
+using Unity.Collections;
 using Unity.Entities;
 using Unity.Mathematics;
 using Unity.Rendering;
@@ -23,8 +24,19 @@ public class HerbivoreAuthoring : MonoBehaviour
     // Consumo adicional de hambre al moverse.
     public float moveHungerRate = 2f;
 
-    // Hambre recuperada al comer una planta.
-    public float hungerGainOnEat = 40f;
+    // Tasa de alimentación (hambre recuperada por segundo).
+    public float eatRate = 40f;
+
+    // Radio en el que pueden detectar plantas.
+    public float plantSeekRadius = 5f;
+
+    [Header("Reproducción")]
+    public float reproductionThreshold = 80f;
+    public float reproductionSeekRadius = 6f;
+    public float reproductionMatingDistance = 1f;
+    public float reproductionCooldown = 10f;
+    public int minOffspring = 1;
+    public int maxOffspring = 2;
 
     // Porcentaje de vida restaurada al comer.
     [Range(0f,1f)] public float healthRestorePercent = 0.25f;
@@ -47,7 +59,8 @@ public class HerbivoreAuthoring : MonoBehaviour
                 MoveSpeed = authoring.moveSpeed,
                 IdleHungerRate = authoring.idleHungerRate,
                 MoveHungerRate = authoring.moveHungerRate,
-                HungerGain = authoring.hungerGainOnEat,
+                EatRate = authoring.eatRate,
+                PlantSeekRadius = authoring.plantSeekRadius,
                 HealthRestorePercent = authoring.healthRestorePercent,
                 ChangeDirectionInterval = authoring.changeDirectionInterval,
                 DirectionTimer = 0f,
@@ -70,6 +83,25 @@ public class HerbivoreAuthoring : MonoBehaviour
                 DecreaseRate = authoring.idleHungerRate,
                 SeekThreshold = authoring.maxHunger * 0.5f,
                 DeathThreshold = 0f
+            });
+
+            // Reproducción y datos informativos.
+            AddComponent(entity, new Reproduction
+            {
+                Threshold = authoring.reproductionThreshold,
+                SeekRadius = authoring.reproductionSeekRadius,
+                MatingDistance = authoring.reproductionMatingDistance,
+                Cooldown = authoring.reproductionCooldown,
+                Timer = 0f,
+                MinOffspring = authoring.minOffspring,
+                MaxOffspring = authoring.maxOffspring
+            });
+
+            AddComponent(entity, new HerbivoreInfo
+            {
+                Name = new FixedString64Bytes(""),
+                Lifetime = 0f,
+                Generation = 1
             });
 
             // Transform y posición inicial del herbívoro.

--- a/Assets/1-Scripts/DOTS/Components/Herbivore.cs
+++ b/Assets/1-Scripts/DOTS/Components/Herbivore.cs
@@ -13,8 +13,11 @@ public struct Herbivore : IComponentData
     /// Consumo adicional de hambre por unidad de velocidad.
     public float MoveHungerRate;
 
-    /// Hambre recuperada al comer una planta.
-    public float HungerGain;
+    /// Tasa a la que recupera hambre al comer (por segundo).
+    public float EatRate;
+
+    /// Radio en celdas en el que puede detectar plantas.
+    public float PlantSeekRadius;
 
     /// Porcentaje de vida máxima que se restaura al comer (0-1).
     public float HealthRestorePercent;

--- a/Assets/1-Scripts/DOTS/Components/HerbivoreInfo.cs
+++ b/Assets/1-Scripts/DOTS/Components/HerbivoreInfo.cs
@@ -1,0 +1,15 @@
+using Unity.Collections;
+using Unity.Entities;
+
+/// <summary>
+/// Información descriptiva y de telemetría de un herbívoro.
+/// </summary>
+public struct HerbivoreInfo : IComponentData
+{
+    /// Nombre único del individuo.
+    public FixedString64Bytes Name;
+    /// Tiempo de vida en segundos.
+    public float Lifetime;
+    /// Generación a la que pertenece.
+    public int Generation;
+}

--- a/Assets/1-Scripts/DOTS/Components/HerbivoreNameGenerator.cs
+++ b/Assets/1-Scripts/DOTS/Components/HerbivoreNameGenerator.cs
@@ -1,0 +1,18 @@
+using Unity.Collections;
+
+/// <summary>
+/// Genera nombres sencillos para herbívoros DOTS.
+/// </summary>
+public static class HerbivoreNameGenerator
+{
+    static int counter;
+
+    public static FixedString64Bytes NextName()
+    {
+        counter++;
+        FixedString64Bytes name = new FixedString64Bytes();
+        name.Append("Herb");
+        name.AppendInt(counter);
+        return name;
+    }
+}

--- a/Assets/1-Scripts/DOTS/Components/Reproduction.cs
+++ b/Assets/1-Scripts/DOTS/Components/Reproduction.cs
@@ -1,0 +1,22 @@
+using Unity.Entities;
+
+/// <summary>
+/// Datos de reproducción de un herbívoro.
+/// </summary>
+public struct Reproduction : IComponentData
+{
+    /// Nivel de hambre necesario para poder reproducirse.
+    public float Threshold;
+    /// Radio de búsqueda activa de pareja.
+    public float SeekRadius;
+    /// Distancia mínima para considerar que están apareados.
+    public float MatingDistance;
+    /// Tiempo de enfriamiento entre reproducciones.
+    public float Cooldown;
+    /// Temporizador restante hasta poder reproducirse de nuevo.
+    public float Timer;
+    /// Número mínimo de crías por reproducción.
+    public int MinOffspring;
+    /// Número máximo de crías por reproducción.
+    public int MaxOffspring;
+}

--- a/Assets/1-Scripts/DOTS/Systems/HerbivoreSpawnerSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/HerbivoreSpawnerSystem.cs
@@ -44,6 +44,12 @@ public partial struct HerbivoreSpawnerSystem : ISystem
                 Scale = 1f
             });
             ecb.AddComponent(e, new GridPosition { Cell = cell });
+            ecb.SetComponent(e, new HerbivoreInfo
+            {
+                Name = HerbivoreNameGenerator.NextName(),
+                Lifetime = 0f,
+                Generation = 1
+            });
         }
 
         // Marcamos que ya se generaron para no repetir.

--- a/Assets/1-Scripts/DOTS/Systems/HerbivoreSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/HerbivoreSystem.cs
@@ -15,7 +15,8 @@ public partial struct HerbivoreSystem : ISystem
     public void OnUpdate(ref SystemState state)
     {
         // Comprobamos que exista una cuadrícula para delimitar el movimiento.
-        if (!SystemAPI.TryGetSingleton<GridManager>(out var grid))
+        if (!SystemAPI.TryGetSingleton<GridManager>(out var grid) ||
+            !SystemAPI.TryGetSingleton<HerbivoreManager>(out var hManager))
             return;
 
         float dt = SystemAPI.Time.DeltaTime;
@@ -34,10 +35,14 @@ public partial struct HerbivoreSystem : ISystem
             plantCells.Add(pgp.ValueRO.Cell);
         }
 
-        // Celdas ocupadas por herbívoros para evitar superposiciones.
+        // Celdas ocupadas por herbívoros para evitar superposiciones y mapa para búsquedas.
         var herbCells = new NativeParallelHashSet<int2>(1024, Allocator.Temp);
-        foreach (var gp in SystemAPI.Query<RefRO<GridPosition>>().WithAll<Herbivore>())
+        var herbMap = new NativeParallelHashMap<int2, Entity>(1024, Allocator.Temp);
+        foreach (var (gp, e) in SystemAPI.Query<RefRO<GridPosition>>().WithAll<Herbivore>().WithEntityAccess())
+        {
             herbCells.Add(gp.ValueRO.Cell);
+            herbMap.TryAdd(gp.ValueRO.Cell, e);
+        }
 
         // Direcciones posibles (8 vecinos alrededor de la celda).
         int2[] dirs = new int2[8]
@@ -47,57 +52,160 @@ public partial struct HerbivoreSystem : ISystem
         };
 
         // Recorremos cada herbívoro.
-        foreach (var (transform, hunger, health, herb, gp, entity) in
-                 SystemAPI.Query<RefRW<LocalTransform>, RefRW<Hunger>, RefRW<Health>, RefRW<Herbivore>, RefRW<GridPosition>>().WithEntityAccess())
+        foreach (var (transform, hunger, health, herb, gp, repro, info, entity) in
+                 SystemAPI.Query<RefRW<LocalTransform>, RefRW<Hunger>, RefRW<Health>, RefRW<Herbivore>, RefRW<GridPosition>, RefRW<Reproduction>, RefRW<HerbivoreInfo>>().WithEntityAccess())
         {
             // Celda actual del herbívoro.
             int2 currentCell = gp.ValueRO.Cell;
+            repro.ValueRW.Timer = math.max(0f, repro.ValueRO.Timer - dt);
 
             // Hambre actual: cuando caen por debajo del umbral buscan comida
             // pero continúan comiendo hasta llenarse por completo.
             bool shouldSeekPlant = hunger.ValueRO.Value <= hunger.ValueRO.SeekThreshold;
             bool isHungry = hunger.ValueRO.Value < hunger.ValueRO.Max;
-            float speed = shouldSeekPlant ? herb.ValueRO.MoveSpeed * 2f : herb.ValueRO.MoveSpeed;
 
-            // Selección de dirección: si necesita buscar, lo hace hacia la planta más cercana.
-            if (shouldSeekPlant && plantCells.Length > 0)
+            bool readyToReproduce = !shouldSeekPlant && hunger.ValueRO.Value >= repro.ValueRO.Threshold && repro.ValueRO.Timer <= 0f;
+
+            float speed = herb.ValueRO.MoveSpeed;
+            bool hasDirection = false;
+
+            if (shouldSeekPlant)
             {
                 float bestDist = float.MaxValue;
                 int2 target = currentCell;
+                float radiusSq = herb.ValueRO.PlantSeekRadius * herb.ValueRO.PlantSeekRadius;
                 for (int i = 0; i < plantCells.Length; i++)
                 {
                     float dist = math.lengthsq((float2)(plantCells[i] - currentCell));
-                    if (dist < bestDist)
+                    if (dist < bestDist && dist <= radiusSq)
                     {
                         bestDist = dist;
                         target = plantCells[i];
                     }
                 }
 
-                int2 diff = target - currentCell;
-                int2 step = new int2(math.clamp(diff.x, -1, 1), math.clamp(diff.y, -1, 1));
-                float3 dir = float3.zero;
-                if (step.x != 0 || step.y != 0)
-                    dir = math.normalize(new float3(step.x, 0f, step.y));
-                herb.ValueRW.MoveDirection = dir;
+                if (bestDist < float.MaxValue)
+                {
+                    int2 diff = target - currentCell;
+                    int2 step = new int2(math.clamp(diff.x, -1, 1), math.clamp(diff.y, -1, 1));
+                    if (step.x != 0 || step.y != 0)
+                    {
+                        herb.ValueRW.MoveDirection = math.normalize(new float3(step.x, 0f, step.y));
+                        hasDirection = true;
+                    }
+                }
+                if (!hasDirection)
+                {
+                    // Sin plantas cercanas, se mueve aleatoriamente para buscarlas.
+                    herb.ValueRW.DirectionTimer -= dt;
+                    if (herb.ValueRO.DirectionTimer <= 0f)
+                    {
+                        int choice = rand.NextInt(8);
+                        int2 d = dirs[choice];
+                        herb.ValueRW.MoveDirection = math.normalize(new float3(d.x, 0f, d.y));
+                        herb.ValueRW.DirectionTimer = herb.ValueRO.ChangeDirectionInterval * 0.5f;
+                    }
+                    speed *= 1.5f;
+                    hasDirection = true;
+                }
+            }
+            else if (readyToReproduce)
+            {
+                float bestDist = float.MaxValue;
+                int2 mateCell = currentCell;
+                Entity mate = Entity.Null;
+                int radius = (int)math.ceil(repro.ValueRO.SeekRadius);
+                for (int x = -radius; x <= radius; x++)
+                {
+                    for (int y = -radius; y <= radius; y++)
+                    {
+                        int2 c = currentCell + new int2(x, y);
+                        if (herbMap.TryGetValue(c, out var cand) && cand != entity)
+                        {
+                            var candRepro = state.EntityManager.GetComponentData<Reproduction>(cand);
+                            var candHunger = state.EntityManager.GetComponentData<Hunger>(cand);
+                            if (candRepro.Timer <= 0f && candHunger.Value >= candRepro.Threshold)
+                            {
+                                float dist = math.lengthsq(new float2(x, y));
+                                if (dist < bestDist)
+                                {
+                                    bestDist = dist;
+                                    mate = cand;
+                                    mateCell = c;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (mate != Entity.Null)
+                {
+                    if (bestDist <= repro.ValueRO.MatingDistance * repro.ValueRO.MatingDistance)
+                    {
+                        // Reproducción
+                        var mateInfo = state.EntityManager.GetComponentData<HerbivoreInfo>(mate);
+                        int offspringCount = rand.NextInt(repro.ValueRO.MinOffspring, repro.ValueRO.MaxOffspring + 1);
+                        int gen = math.max(info.ValueRO.Generation, mateInfo.Generation) + 1;
+                        for (int i = 0; i < offspringCount; i++)
+                        {
+                            int2 cell = currentCell;
+                            var child = ecb.Instantiate(hManager.Prefab);
+                            ecb.SetComponent(child, new LocalTransform
+                            {
+                                Position = new float3(cell.x, 0f, cell.y),
+                                Rotation = quaternion.identity,
+                                Scale = 1f
+                            });
+                            ecb.AddComponent(child, new GridPosition { Cell = cell });
+                            ecb.SetComponent(child, new HerbivoreInfo
+                            {
+                                Name = HerbivoreNameGenerator.NextName(),
+                                Lifetime = 0f,
+                                Generation = gen
+                            });
+                        }
+                        repro.ValueRW.Timer = repro.ValueRO.Cooldown;
+                        var mateRepro = state.EntityManager.GetComponentData<Reproduction>(mate);
+                        mateRepro.Timer = mateRepro.Cooldown;
+                        state.EntityManager.SetComponentData(mate, mateRepro);
+                    }
+                    else
+                    {
+                        int2 diff = mateCell - currentCell;
+                        int2 step = new int2(math.clamp(diff.x, -1, 1), math.clamp(diff.y, -1, 1));
+                        if (step.x != 0 || step.y != 0)
+                        {
+                            herb.ValueRW.MoveDirection = math.normalize(new float3(step.x, 0f, step.y));
+                            hasDirection = true;
+                        }
+                    }
+                }
+
+                if (!hasDirection)
+                {
+                    herb.ValueRW.DirectionTimer -= dt;
+                    if (herb.ValueRO.DirectionTimer <= 0f)
+                    {
+                        int choice = rand.NextInt(8);
+                        int2 d = dirs[choice];
+                        herb.ValueRW.MoveDirection = math.normalize(new float3(d.x, 0f, d.y));
+                        herb.ValueRW.DirectionTimer = herb.ValueRO.ChangeDirectionInterval;
+                    }
+                    speed *= 0.75f;
+                    hasDirection = true;
+                }
             }
             else
             {
-                // Contador para cambiar de dirección aleatoriamente.
                 herb.ValueRW.DirectionTimer -= dt;
                 if (herb.ValueRO.DirectionTimer <= 0f)
                 {
-                    int choice = rand.NextInt(9); // 0 = quieto
-                    if (choice == 0)
-                        herb.ValueRW.MoveDirection = float3.zero;
-                    else
-                    {
-                        int2 d = dirs[choice - 1];
-                        herb.ValueRW.MoveDirection = math.normalize(new float3(d.x, 0f, d.y));
-                    }
-                    herb.ValueRW.DirectionTimer = herb.ValueRO.ChangeDirectionInterval;
+                    int choice = rand.NextInt(8);
+                    int2 d = dirs[choice];
+                    herb.ValueRW.MoveDirection = math.normalize(new float3(d.x, 0f, d.y));
+                    herb.ValueRW.DirectionTimer = herb.ValueRO.ChangeDirectionInterval * 1.5f;
                 }
-
+                speed *= 0.5f;
             }
             // Movimiento con acumulación subcelda para permanecer en la cuadrícula.
             float3 move = herb.ValueRO.MoveDirection * speed * dt + herb.ValueRO.MoveRemainder;
@@ -155,10 +263,10 @@ public partial struct HerbivoreSystem : ISystem
             float hungerRate = herb.ValueRO.MoveDirection.x == 0f && herb.ValueRO.MoveDirection.z == 0f
                 ? herb.ValueRO.IdleHungerRate
                 : herb.ValueRO.IdleHungerRate + herb.ValueRO.MoveHungerRate * speed;
-            hunger.ValueRW.Value -= hungerRate * dt;
+            hunger.ValueRW.Value = math.max(0f, hunger.ValueRO.Value - hungerRate * dt);
 
-            // Si el hambre llega a 0 empezamos a perder vida.
-            if (hunger.ValueRO.Value <= 0f)
+            // Si el hambre llega al umbral mínimo empezamos a perder vida.
+            if (hunger.ValueRO.Value <= hunger.ValueRO.DeathThreshold)
             {
                 health.ValueRW.Value -= dt;
                 if (health.ValueRO.Value <= 0f)
@@ -177,7 +285,7 @@ public partial struct HerbivoreSystem : ISystem
             if (isHungry && plants.TryGetFirstValue(forwardCell, out var plantEntity, out _))
             {
                 // Restablecemos hambre y vida de forma gradual.
-                float eat = herb.ValueRO.HungerGain * dt;
+                float eat = herb.ValueRO.EatRate * dt;
                 hunger.ValueRW.Value = math.min(hunger.ValueRO.Max, hunger.ValueRO.Value + eat);
                 float healthGain = health.ValueRO.Max * herb.ValueRO.HealthRestorePercent * dt;
                 health.ValueRW.Value = math.min(health.ValueRO.Max, health.ValueRO.Value + healthGain);
@@ -195,11 +303,15 @@ public partial struct HerbivoreSystem : ISystem
                 else
                     state.EntityManager.SetComponentData(plantEntity, plant);
             }
+
+            // Tiempo de vida del herbívoro.
+            info.ValueRW.Lifetime += dt;
         }
         // Ejecutamos los cambios y liberamos la memoria usada.
         ecb.Playback(state.EntityManager);
         plants.Dispose();
         plantCells.Dispose();
         herbCells.Dispose();
+        herbMap.Dispose();
     }
 }


### PR DESCRIPTION
## Summary
- Clamp herbivore hunger to zero, consume plants at a fixed rate and search for food within a detection radius
- Add reproduction system with pair seeking, cooldowns and configurable offspring counts
- Track individual telemetry with unique names, lifetime and generation data

## Testing
- ⚠️ `dotnet build` *(command not found; attempted to install dotnet but no package available)*

------
https://chatgpt.com/codex/tasks/task_b_689baa6d486c8326a28763aa4219b413