### PR TITLE
Add herbivore state machine and predator awareness

### DIFF
--- a/Assets/1-Scripts/DOTS/Authoring/HerbivoreAuthoring.cs
+++ b/Assets/1-Scripts/DOTS/Authoring/HerbivoreAuthoring.cs
@@ -30,6 +30,22 @@ public class HerbivoreAuthoring : MonoBehaviour
     // Radio en el que pueden detectar plantas.
     public float plantSeekRadius = 5f;
 
+    [Header("Percepción")]
+    public float predatorSenseRadius = 6f;
+
+    [Header("Separación")]
+    public float separationRadius = 1.5f;
+    public float separationForce = 1f;
+
+    [Header("Decisiones")]
+    public float decisionCooldown = 0.2f;
+
+    [Header("Colores de estado")]
+    public Color wanderColor = Color.green;
+    public Color eatColor = Color.yellow;
+    public Color mateColor = Color.cyan;
+    public Color fleeColor = Color.red;
+
     [Header("Reproducción")]
     public float reproductionThreshold = 80f;
     public float reproductionSeekRadius = 6f;
@@ -69,6 +85,30 @@ public class HerbivoreAuthoring : MonoBehaviour
                 KnownPlantCell = int2.zero,
                 HasKnownPlant = 0,
                 IsEating = 0
+            });
+
+            AddComponent(entity, new HerbivoreState
+            {
+                Current = HerbivoreBehaviour.Wander,
+                DecisionCooldown = authoring.decisionCooldown
+            });
+
+            AddComponent(entity, new HerbivoreDecisionTimer { TimeLeft = 0f });
+
+            AddComponent(entity, new PredatorSense { Radius = authoring.predatorSenseRadius });
+
+            AddComponent(entity, new SeparationRadius
+            {
+                Value = authoring.separationRadius,
+                Force = authoring.separationForce
+            });
+
+            AddComponent(entity, new StateColor
+            {
+                Wander = new float4(authoring.wanderColor.r, authoring.wanderColor.g, authoring.wanderColor.b, authoring.wanderColor.a),
+                Eat = new float4(authoring.eatColor.r, authoring.eatColor.g, authoring.eatColor.b, authoring.eatColor.a),
+                Mate = new float4(authoring.mateColor.r, authoring.mateColor.g, authoring.mateColor.b, authoring.mateColor.a),
+                Flee = new float4(authoring.fleeColor.r, authoring.fleeColor.g, authoring.fleeColor.b, authoring.fleeColor.a)
             });
 
             // Componentes de salud y hambre iniciales.

--- a/Assets/1-Scripts/DOTS/Authoring/HerbivoreManagerAuthoring.cs
+++ b/Assets/1-Scripts/DOTS/Authoring/HerbivoreManagerAuthoring.cs
@@ -8,8 +8,21 @@ public class HerbivoreManagerAuthoring : MonoBehaviour
     // Prefab del herbívoro que se instanciará.
     public GameObject herbivorePrefab;
 
+    // Prefab de la carne soltada al morir.
+    public GameObject meatPrefab;
+
     // Número de herbívoros iniciales.
     public int initialCount = 20;
+
+    [Header("Genética")]
+    // Permite desactivar la herencia de estadísticas.
+    public bool enableGenetics = true;
+
+    // Probabilidad de mutación para cada estadística.
+    [Range(0f,1f)] public float mutationChance = 0.1f;
+
+    // Escala de variación aplicada al mutar.
+    public float mutationScale = 0.1f;
 
     // Convierte los datos de authoring en un componente de configuración.
 
@@ -21,8 +34,12 @@ public class HerbivoreManagerAuthoring : MonoBehaviour
             AddComponent(entity, new HerbivoreManager
             {
                 Prefab = GetEntity(authoring.herbivorePrefab, TransformUsageFlags.Dynamic),
+                MeatPrefab = GetEntity(authoring.meatPrefab, TransformUsageFlags.Dynamic),
                 InitialCount = authoring.initialCount,
-                Initialized = 0
+                Initialized = 0,
+                GeneticsEnabled = (byte)(authoring.enableGenetics ? 1 : 0),
+                MutationChance = authoring.mutationChance,
+                MutationScale = authoring.mutationScale
             });
         }
     }
@@ -34,10 +51,22 @@ public struct HerbivoreManager : IComponentData
     /// Prefab del herbívoro convertido a entidad.
     public Entity Prefab;
 
+    /// Prefab de la carne generada al morir.
+    public Entity MeatPrefab;
+
     /// Cantidad inicial de herbívoros.
     public int InitialCount;
 
     /// Bandera para no inicializar dos veces.
 
     public byte Initialized;
+
+    /// Permite activar o desactivar la genética.
+    public byte GeneticsEnabled;
+
+    /// Probabilidad de que una estadística muté en la reproducción.
+    public float MutationChance;
+
+    /// Escala de variación aplicada a las mutaciones.
+    public float MutationScale;
 }

--- a/Assets/1-Scripts/DOTS/Components/HerbivoreState.cs
+++ b/Assets/1-Scripts/DOTS/Components/HerbivoreState.cs
@@ -1,0 +1,29 @@
+using Unity.Entities;
+
+/// <summary>
+/// Estado actual del herbívoro y datos para controlar el ritmo de decisiones.
+/// </summary>
+public struct HerbivoreState : IComponentData
+{
+    public HerbivoreBehaviour Current;
+    public float DecisionCooldown;
+}
+
+/// <summary>
+/// Temporizador usado para evaluar la próxima decisión del herbívoro.
+/// </summary>
+public struct HerbivoreDecisionTimer : IComponentData
+{
+    public float TimeLeft;
+}
+
+/// <summary>
+/// Posibles estados del herbívoro en la máquina de decisiones.
+/// </summary>
+public enum HerbivoreBehaviour : byte
+{
+    Wander,
+    Eat,
+    Mate,
+    Flee
+}

--- a/Assets/1-Scripts/DOTS/Components/MeatDropTag.cs
+++ b/Assets/1-Scripts/DOTS/Components/MeatDropTag.cs
@@ -1,0 +1,6 @@
+using Unity.Entities;
+
+/// <summary>
+/// Etiqueta para el prefab que representa la carne soltada por un herbívoro al morir.
+/// </summary>
+public struct MeatDropTag : IComponentData { }

--- a/Assets/1-Scripts/DOTS/Components/PredatorSense.cs
+++ b/Assets/1-Scripts/DOTS/Components/PredatorSense.cs
@@ -1,0 +1,22 @@
+using Unity.Entities;
+using Unity.Mathematics;
+
+/// <summary>
+/// Configuración de percepción de depredadores para un herbívoro.
+/// </summary>
+public struct PredatorSense : IComponentData
+{
+    /// Radio dentro del cual se detectan depredadores.
+    public float Radius;
+}
+
+/// <summary>
+/// Datos de huida activa de un herbívoro.
+/// </summary>
+public struct Fleeing : IComponentData
+{
+    /// Tiempo restante de huida.
+    public float TimeLeft;
+    /// Dirección de escape normalizada.
+    public float3 Direction;
+}

--- a/Assets/1-Scripts/DOTS/Components/SeparationRadius.cs
+++ b/Assets/1-Scripts/DOTS/Components/SeparationRadius.cs
@@ -1,0 +1,12 @@
+using Unity.Entities;
+
+/// <summary>
+/// Parámetros para aplicar una fuerza de separación entre herbívoros.
+/// </summary>
+public struct SeparationRadius : IComponentData
+{
+    /// Radio máximo en el que se aplica la separación.
+    public float Value;
+    /// Intensidad de la fuerza de separación.
+    public float Force;
+}

--- a/Assets/1-Scripts/DOTS/Components/StateColor.cs
+++ b/Assets/1-Scripts/DOTS/Components/StateColor.cs
@@ -1,0 +1,13 @@
+using Unity.Entities;
+using Unity.Mathematics;
+
+/// <summary>
+/// Colores usados para visualizar el estado del herbívoro.
+/// </summary>
+public struct StateColor : IComponentData
+{
+    public float4 Wander;
+    public float4 Eat;
+    public float4 Mate;
+    public float4 Flee;
+}

--- a/Assets/1-Scripts/DOTS/Systems/FleeingMovementSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/FleeingMovementSystem.cs
@@ -1,0 +1,32 @@
+using Unity.Burst;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+/// <summary>
+/// Mueve a los herbívoros que están huyendo, ignorando otras conductas.
+/// </summary>
+[BurstCompile]
+public partial struct FleeingMovementSystem : ISystem
+{
+    public void OnUpdate(ref SystemState state)
+    {
+        if (!SystemAPI.TryGetSingleton<GridManager>(out var grid))
+            return;
+
+        float dt = SystemAPI.Time.DeltaTime;
+        foreach (var (transform, herb, gp, fleeing, entity) in
+                 SystemAPI.Query<RefRW<LocalTransform>, RefRO<Herbivore>, RefRW<GridPosition>, RefRW<Fleeing>>().WithEntityAccess())
+        {
+            float speed = herb.ValueRO.MoveSpeed * 2f;
+            transform.ValueRW.Position += fleeing.ValueRO.Direction * speed * dt;
+            fleeing.ValueRW.TimeLeft -= dt;
+            gp.ValueRW.Cell = new int2((int)math.round(transform.ValueRO.Position.x / grid.CellSize),
+                                       (int)math.round(transform.ValueRO.Position.z / grid.CellSize));
+            if (fleeing.ValueRO.TimeLeft <= 0f)
+            {
+                state.EntityManager.RemoveComponent<Fleeing>(entity);
+            }
+        }
+    }
+}

--- a/Assets/1-Scripts/DOTS/Systems/HerbivoreDeathSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/HerbivoreDeathSystem.cs
@@ -1,0 +1,38 @@
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+/// <summary>
+/// Instancia una entidad de carne cuando un herbívoro muere.
+/// </summary>
+[BurstCompile]
+public partial struct HerbivoreDeathSystem : ISystem
+{
+    public void OnUpdate(ref SystemState state)
+    {
+        if (!SystemAPI.TryGetSingleton<HerbivoreManager>(out var manager))
+            return;
+        if (manager.MeatPrefab == Entity.Null)
+            return;
+
+        var ecb = new EntityCommandBuffer(Allocator.Temp);
+        foreach (var (health, gp, entity) in SystemAPI.Query<RefRO<Health>, RefRO<GridPosition>>().WithAll<Herbivore>().WithEntityAccess())
+        {
+            if (health.ValueRO.Value > 0f)
+                continue;
+            var drop = ecb.Instantiate(manager.MeatPrefab);
+            ecb.SetComponent(drop, new LocalTransform
+            {
+                Position = new float3(gp.ValueRO.Cell.x, 0f, gp.ValueRO.Cell.y),
+                Rotation = quaternion.identity,
+                Scale = 1f
+            });
+            ecb.AddComponent<MeatDropTag>(drop);
+            ecb.DestroyEntity(entity);
+        }
+        ecb.Playback(state.EntityManager);
+        ecb.Dispose();
+    }
+}

--- a/Assets/1-Scripts/DOTS/Systems/HerbivoreDecisionSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/HerbivoreDecisionSystem.cs
@@ -1,0 +1,44 @@
+using Unity.Burst;
+using Unity.Entities;
+using Unity.Mathematics;
+
+/// <summary>
+/// Evalúa periódicamente el estado del herbívoro usando prioridades.
+/// </summary>
+[BurstCompile]
+public partial struct HerbivoreDecisionSystem : ISystem
+{
+    public void OnUpdate(ref SystemState state)
+    {
+        float dt = SystemAPI.Time.DeltaTime;
+        foreach (var (hState, timer, hunger, repro, entity) in
+                 SystemAPI.Query<RefRW<HerbivoreState>, RefRW<HerbivoreDecisionTimer>, RefRO<Hunger>, RefRO<Reproduction>>().WithEntityAccess())
+        {
+            timer.ValueRW.TimeLeft -= dt;
+            if (timer.ValueRO.TimeLeft > 0f)
+                continue;
+
+            timer.ValueRW.TimeLeft = hState.ValueRO.DecisionCooldown;
+
+            if (SystemAPI.HasComponent<Fleeing>(entity))
+            {
+                hState.ValueRW.Current = HerbivoreBehaviour.Flee;
+                continue;
+            }
+
+            bool readyToMate = hunger.ValueRO.Value >= repro.ValueRO.Threshold && repro.ValueRO.Timer <= 0f;
+            if (readyToMate)
+            {
+                hState.ValueRW.Current = HerbivoreBehaviour.Mate;
+            }
+            else if (hunger.ValueRO.Value < hunger.ValueRO.SeekThreshold)
+            {
+                hState.ValueRW.Current = HerbivoreBehaviour.Eat;
+            }
+            else
+            {
+                hState.ValueRW.Current = HerbivoreBehaviour.Wander;
+            }
+        }
+    }
+}

--- a/Assets/1-Scripts/DOTS/Systems/HerbivoreVisualSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/HerbivoreVisualSystem.cs
@@ -1,0 +1,30 @@
+using Unity.Burst;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Rendering;
+using Unity.Transforms;
+
+/// <summary>
+/// Ajusta color y escala de los herbívoros según su estado y salud.
+/// </summary>
+[BurstCompile]
+public partial struct HerbivoreVisualSystem : ISystem
+{
+    public void OnUpdate(ref SystemState state)
+    {
+        foreach (var (hState, health, color, transform, sColor) in
+                 SystemAPI.Query<RefRO<HerbivoreState>, RefRO<Health>, RefRW<URPMaterialPropertyBaseColor>, RefRW<LocalTransform>, RefRO<StateColor>>())
+        {
+            float4 c = sColor.ValueRO.Wander;
+            switch (hState.ValueRO.Current)
+            {
+                case HerbivoreBehaviour.Eat: c = sColor.ValueRO.Eat; break;
+                case HerbivoreBehaviour.Mate: c = sColor.ValueRO.Mate; break;
+                case HerbivoreBehaviour.Flee: c = sColor.ValueRO.Flee; break;
+            }
+            color.ValueRW.Value = c;
+            float scale = math.max(0.3f, health.ValueRO.Value / health.ValueRO.Max);
+            transform.ValueRW.Scale = scale;
+        }
+    }
+}

--- a/Assets/1-Scripts/DOTS/Systems/PredatorSensingSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/PredatorSensingSystem.cs
@@ -1,0 +1,47 @@
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+/// <summary>
+/// Detecta depredadores cercanos y activa la huida de los herbívoros.
+/// </summary>
+[BurstCompile]
+public partial struct PredatorSensingSystem : ISystem
+{
+    public void OnUpdate(ref SystemState state)
+    {
+        var predators = new NativeList<float3>(Allocator.Temp);
+        foreach (var (t, _) in SystemAPI.Query<RefRO<LocalTransform>>().WithAll<CarnivoreTag>())
+        {
+            predators.Add(t.ValueRO.Position);
+        }
+
+        foreach (var (t, sense, entity) in SystemAPI.Query<RefRO<LocalTransform>, RefRO<PredatorSense>>().WithEntityAccess())
+        {
+            float3 escape = float3.zero;
+            bool seen = false;
+            for (int i = 0; i < predators.Length; i++)
+            {
+                float3 diff = t.ValueRO.Position - predators[i];
+                float distSq = math.lengthsq(diff);
+                if (distSq <= sense.ValueRO.Radius * sense.ValueRO.Radius)
+                {
+                    escape += math.normalize(diff);
+                    seen = true;
+                }
+            }
+
+            if (seen)
+            {
+                var fleeing = new Fleeing { TimeLeft = 3f, Direction = math.normalize(escape) };
+                if (SystemAPI.HasComponent<Fleeing>(entity))
+                    SystemAPI.SetComponent(entity, fleeing);
+                else
+                    state.EntityManager.AddComponentData(entity, fleeing);
+            }
+        }
+        predators.Dispose();
+    }
+}

--- a/Assets/1-Scripts/DOTS/Systems/SeparationSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/SeparationSystem.cs
@@ -1,0 +1,52 @@
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+/// <summary>
+/// Aplica una fuerza de repulsión entre herbívoros cercanos para evitar apelotonamientos.
+/// </summary>
+[BurstCompile]
+public partial struct SeparationSystem : ISystem
+{
+    public void OnUpdate(ref SystemState state)
+    {
+        var positions = new NativeList<float3>(Allocator.Temp);
+        var entities = new NativeList<Entity>(Allocator.Temp);
+        foreach (var (t, e) in SystemAPI.Query<RefRO<LocalTransform>>().WithAll<Herbivore>().WithEntityAccess())
+        {
+            positions.Add(t.ValueRO.Position);
+            entities.Add(e);
+        }
+
+        float dt = SystemAPI.Time.DeltaTime;
+        for (int i = 0; i < entities.Length; i++)
+        {
+            var ent = entities[i];
+            if (!SystemAPI.HasComponent<SeparationRadius>(ent))
+                continue;
+            var sep = SystemAPI.GetComponent<SeparationRadius>(ent);
+            float3 pos = positions[i];
+            float3 force = float3.zero;
+            for (int j = 0; j < entities.Length; j++)
+            {
+                if (i == j) continue;
+                float3 diff = pos - positions[j];
+                float dist = math.length(diff);
+                if (dist > 0f && dist < sep.Value)
+                {
+                    force += math.normalize(diff) * (sep.Force / dist);
+                }
+            }
+            if (!force.Equals(float3.zero))
+            {
+                var herb = SystemAPI.GetComponent<Herbivore>(ent);
+                herb.MoveDirection = math.normalize(herb.MoveDirection + force * dt);
+                SystemAPI.SetComponent(ent, herb);
+            }
+        }
+        positions.Dispose();
+        entities.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary
- define components for herbivore state, predator sense, separation and visual colours
- implement decision, sensing, fleeing, separation and visual systems
- spawn meat prefab on herbivore death via manager configuration

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bbe8b61148326a64575e0d67f19fd