### PR TITLE
Smooth DOTS herbivore movement

### DIFF
--- a/Assets/1-Scripts/DOTS/Systems/HerbivoreSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/HerbivoreSystem.cs
@@ -451,9 +451,10 @@ public partial struct HerbivoreSystem : ISystem
             targetCell.x = math.clamp(targetCell.x, -bounds.x, bounds.x);
             targetCell.y = math.clamp(targetCell.y, -bounds.y, bounds.y);
 
+            float3 worldOffset = new float3(move.x, 0f, move.z) * grid.CellSize;
             if ((!herbCells.Contains(targetCell) && !obstacles.Contains(targetCell)) || math.all(targetCell == currentCell))
             {
-                float3 targetPos = new float3(targetCell.x * grid.CellSize, 0f, targetCell.y * grid.CellSize);
+                float3 targetPos = new float3(targetCell.x * grid.CellSize, 0f, targetCell.y * grid.CellSize) + worldOffset;
                 transform.ValueRW.Position = targetPos;
                 gp.ValueRW.Cell = targetCell;
                 herbCells.Remove(currentCell);


### PR DESCRIPTION
## Summary
- Smooth herbivore movement by applying sub-cell offset instead of cell step teleportation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_b_689bcf385ec08326b758bc2049443cbf