### PR TITLE
Ensure plants spawn after obstacles

### DIFF
--- a/Assets/1-Scripts/DOTS/Systems/PlantSpawnerSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/PlantSpawnerSystem.cs
@@ -5,7 +5,9 @@ using Unity.Mathematics;
 using Unity.Transforms;
 
 /// Genera el conjunto inicial de plantas definido por PlantManager.
+/// Se ejecuta después de la creación de obstáculos para evitar solapamientos.
 [BurstCompile]
+[UpdateAfter(typeof(ObstacleSpawnerSystem))]
 public partial struct PlantSpawnerSystem : ISystem
 {
     public void OnUpdate(ref SystemState state)
@@ -13,6 +15,10 @@ public partial struct PlantSpawnerSystem : ISystem
         // Obtenemos el gestor de plantas y los datos de la cuadrícula.
         if (!SystemAPI.TryGetSingletonRW<PlantManager>(out var managerRw) ||
             !SystemAPI.TryGetSingleton<GridManager>(out var grid))
+            return;
+        // Aseguramos que los obstáculos se hayan generado antes de comenzar.
+        if (!SystemAPI.TryGetSingleton<ObstacleManager>(out var obstacleManager) ||
+            obstacleManager.Initialized == 0)
             return;
 
         // Solo ejecutamos una vez al inicio.


### PR DESCRIPTION
## Summary
- schedule plant spawning after obstacle generation to avoid overlap
- block plant spawning until obstacle data is available

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689db940dc7c83268f10a6a6419e0648