### PR TITLE
Restore herbivore pathfinding and stable movement

### DIFF
--- a/Assets/1-Scripts/DOTS/Systems/HerbivoreSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/HerbivoreSystem.cs
@@ -434,49 +434,62 @@ public partial struct HerbivoreSystem : ISystem
                     hasDirection = true;
                 }
             }
-
-            float3 move = herb.ValueRO.MoveDirection * speed * dt + herb.ValueRO.MoveRemainder;
-            int2 delta = int2.zero;
-
-            if (math.abs(herb.ValueRO.MoveDirection.x) > 0f && math.abs(herb.ValueRO.MoveDirection.z) > 0f)
+            if (!hasDirection)
             {
-                int stepX = (int)math.floor(math.abs(move.x));
-                int stepZ = (int)math.floor(math.abs(move.z));
-                int steps = math.min(stepX, stepZ);
-                if (steps > 0)
-                {
-                    delta = new int2((int)math.sign(move.x) * steps, (int)math.sign(move.z) * steps);
-                    move -= new float3(delta.x, 0f, delta.y);
-                }
-            }
-            else
-            {
-                int stepX = (int)math.floor(math.abs(move.x));
-                int stepZ = (int)math.floor(math.abs(move.z));
-                if (stepX != 0 || stepZ != 0)
-                {
-                    delta = new int2((int)math.sign(move.x) * stepX, (int)math.sign(move.z) * stepZ);
-                    move -= new float3(delta.x, 0f, delta.y);
-                }
+                herb.ValueRW.MoveDirection = float3.zero;
             }
 
-            herb.ValueRW.MoveRemainder = move;
-            int2 targetCell = currentCell + delta;
-            targetCell.x = math.clamp(targetCell.x, -bounds.x, bounds.x);
-            targetCell.y = math.clamp(targetCell.y, -bounds.y, bounds.y);
-
-            if ((!herbCells.Contains(targetCell) && !obstacles.Contains(targetCell)) || math.all(targetCell == currentCell))
-            {
-                float3 targetPos = new float3(targetCell.x * grid.CellSize, 0f, targetCell.y * grid.CellSize);
-                transform.ValueRW.Position = targetPos;
-                gp.ValueRW.Cell = targetCell;
-                herbCells.Remove(currentCell);
-                herbCells.Add(targetCell);
-            }
-            else
+            if (math.all(herb.ValueRO.MoveDirection == float3.zero))
             {
                 transform.ValueRW.Position = new float3(currentCell.x * grid.CellSize, 0f, currentCell.y * grid.CellSize);
                 herb.ValueRW.MoveRemainder = float3.zero;
+            }
+            else
+            {
+                float3 move = herb.ValueRO.MoveDirection * speed * dt + herb.ValueRO.MoveRemainder;
+                int2 delta = int2.zero;
+
+                if (math.abs(herb.ValueRO.MoveDirection.x) > 0f && math.abs(herb.ValueRO.MoveDirection.z) > 0f)
+                {
+                    int stepX = (int)math.floor(math.abs(move.x));
+                    int stepZ = (int)math.floor(math.abs(move.z));
+                    int steps = math.min(stepX, stepZ);
+                    if (steps > 0)
+                    {
+                        delta = new int2((int)math.sign(move.x) * steps, (int)math.sign(move.z) * steps);
+                        move -= new float3(delta.x, 0f, delta.y);
+                    }
+                }
+                else
+                {
+                    int stepX = (int)math.floor(math.abs(move.x));
+                    int stepZ = (int)math.floor(math.abs(move.z));
+                    if (stepX != 0 || stepZ != 0)
+                    {
+                        delta = new int2((int)math.sign(move.x) * stepX, (int)math.sign(move.z) * stepZ);
+                        move -= new float3(delta.x, 0f, delta.y);
+                    }
+                }
+
+                herb.ValueRW.MoveRemainder = move;
+                int2 targetCell = currentCell + delta;
+                targetCell.x = math.clamp(targetCell.x, -bounds.x, bounds.x);
+                targetCell.y = math.clamp(targetCell.y, -bounds.y, bounds.y);
+
+                float3 worldOffset = new float3(move.x, 0f, move.z) * grid.CellSize;
+                if ((!herbCells.Contains(targetCell) && !obstacles.Contains(targetCell)) || math.all(targetCell == currentCell))
+                {
+                    float3 targetPos = new float3(targetCell.x * grid.CellSize, 0f, targetCell.y * grid.CellSize) + worldOffset;
+                    transform.ValueRW.Position = targetPos;
+                    gp.ValueRW.Cell = targetCell;
+                    herbCells.Remove(currentCell);
+                    herbCells.Add(targetCell);
+                }
+                else
+                {
+                    transform.ValueRW.Position = new float3(currentCell.x * grid.CellSize, 0f, currentCell.y * grid.CellSize);
+                    herb.ValueRW.MoveRemainder = float3.zero;
+                }
             }
 
             if (!math.all(herb.ValueRO.MoveDirection == float3.zero))


### PR DESCRIPTION
## Summary
- Reinstate breadth-first search to guide herbivores around obstacles
- Smooth herbivore travel with sub-cell offsets and reset direction when idle to prevent sliding

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_b_68a0c71af4308326b0f2c4cee9aa6f5c