### PR TITLE
feat: add debug agents with path visualization

### DIFF
--- a/Assets/1-Scripts/DOTS/Authoring/DebugAgentAuthoring.cs
+++ b/Assets/1-Scripts/DOTS/Authoring/DebugAgentAuthoring.cs
@@ -1,0 +1,26 @@
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using UnityEngine;
+
+/// Autoría del prefab de agente de depuración.
+public class DebugAgentAuthoring : MonoBehaviour
+{
+    // Velocidad de movimiento en celdas por segundo.
+    public float moveSpeed = 5f;
+
+    class Baker : Baker<DebugAgentAuthoring>
+    {
+        public override void Bake(DebugAgentAuthoring authoring)
+        {
+            var entity = GetEntity(TransformUsageFlags.Dynamic);
+            AddComponent(entity, new DebugAgent
+            {
+                Target = int2.zero,
+                MoveSpeed = authoring.moveSpeed
+            });
+            AddComponent(entity, LocalTransform.FromPositionRotationScale(float3.zero, quaternion.identity, 1f));
+            AddComponent(entity, new GridPosition { Cell = int2.zero });
+        }
+    }
+}

--- a/Assets/1-Scripts/DOTS/Authoring/DebugAgentAuthoring.cs.meta
+++ b/Assets/1-Scripts/DOTS/Authoring/DebugAgentAuthoring.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: eef10ca5045a4c0e854ec6c5781418b9

--- a/Assets/1-Scripts/DOTS/Authoring/DebugAgentManagerAuthoring.cs
+++ b/Assets/1-Scripts/DOTS/Authoring/DebugAgentManagerAuthoring.cs
@@ -1,0 +1,34 @@
+using Unity.Entities;
+using UnityEngine;
+
+/// Autoría para configurar la generación de agentes de depuración.
+public class DebugAgentManagerAuthoring : MonoBehaviour
+{
+    // Prefab del agente de depuración.
+    public GameObject agentPrefab;
+
+    // Número de agentes iniciales.
+    public int count = 5;
+
+    class Baker : Baker<DebugAgentManagerAuthoring>
+    {
+        public override void Bake(DebugAgentManagerAuthoring authoring)
+        {
+            var entity = GetEntity(TransformUsageFlags.None);
+            AddComponent(entity, new DebugAgentManager
+            {
+                Prefab = GetEntity(authoring.agentPrefab, TransformUsageFlags.Dynamic),
+                Count = authoring.count,
+                Initialized = 0
+            });
+        }
+    }
+}
+
+/// Componente singleton que controla a los agentes de depuración.
+public struct DebugAgentManager : IComponentData
+{
+    public Entity Prefab;
+    public int Count;
+    public byte Initialized;
+}

--- a/Assets/1-Scripts/DOTS/Authoring/DebugAgentManagerAuthoring.cs.meta
+++ b/Assets/1-Scripts/DOTS/Authoring/DebugAgentManagerAuthoring.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 193ac54b0b29428cbbff4297be0fd284

--- a/Assets/1-Scripts/DOTS/Components/DebugAgent.cs
+++ b/Assets/1-Scripts/DOTS/Components/DebugAgent.cs
@@ -1,0 +1,12 @@
+using Unity.Entities;
+using Unity.Mathematics;
+
+/// Componente para agentes de depuración que se mueven aleatoriamente por la cuadrícula.
+public struct DebugAgent : IComponentData
+{
+    /// Celda objetivo actual.
+    public int2 Target;
+
+    /// Velocidad de movimiento en celdas por segundo.
+    public float MoveSpeed;
+}

--- a/Assets/1-Scripts/DOTS/Components/DebugAgent.cs.meta
+++ b/Assets/1-Scripts/DOTS/Components/DebugAgent.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8988cd3f61cc4c60a9787401d954dc8f

--- a/Assets/1-Scripts/DOTS/Systems/DebugAgentSpawnerSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/DebugAgentSpawnerSystem.cs
@@ -1,0 +1,51 @@
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+/// Genera los agentes de depuración configurados por DebugAgentManager.
+[BurstCompile]
+public partial struct DebugAgentSpawnerSystem : ISystem
+{
+    public void OnUpdate(ref SystemState state)
+    {
+        if (!SystemAPI.TryGetSingletonRW<DebugAgentManager>(out var managerRw) ||
+            !SystemAPI.TryGetSingleton<GridManager>(out var grid))
+            return;
+
+        if (managerRw.ValueRO.Initialized != 0)
+            return;
+
+        var manager = managerRw.ValueRO;
+        var ecb = new EntityCommandBuffer(Allocator.Temp);
+        var rand = Unity.Mathematics.Random.CreateFromIndex(11);
+        float2 area = grid.AreaSize;
+        int2 half = (int2)(area / 2f);
+
+        var prefabData = state.EntityManager.GetComponentData<DebugAgent>(manager.Prefab);
+
+        for (int i = 0; i < manager.Count; i++)
+        {
+            int2 cell = new int2(
+                rand.NextInt(-half.x, half.x + 1),
+                rand.NextInt(-half.y, half.y + 1));
+
+            var e = ecb.Instantiate(manager.Prefab);
+            ecb.SetComponent(e, new LocalTransform
+            {
+                Position = new float3(cell.x, 0f, cell.y),
+                Rotation = quaternion.identity,
+                Scale = 1f
+            });
+            ecb.AddComponent(e, new GridPosition { Cell = cell });
+            var agent = prefabData;
+            agent.Target = cell;
+            ecb.SetComponent(e, agent);
+        }
+
+        manager.Initialized = 1;
+        managerRw.ValueRW = manager;
+        ecb.Playback(state.EntityManager);
+    }
+}

--- a/Assets/1-Scripts/DOTS/Systems/DebugAgentSpawnerSystem.cs.meta
+++ b/Assets/1-Scripts/DOTS/Systems/DebugAgentSpawnerSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 49872ea326264365aae34bd089fa7011

--- a/Assets/1-Scripts/DOTS/Systems/DebugAgentSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/DebugAgentSystem.cs
@@ -1,0 +1,93 @@
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using UnityEngine;
+
+/// Sistema de movimiento para los agentes de depuración.
+[UpdateAfter(typeof(ObstacleRegistrySystem))]
+public partial struct DebugAgentSystem : ISystem
+{
+    public void OnUpdate(ref SystemState state)
+    {
+        if (!SystemAPI.TryGetSingleton<GridManager>(out var grid))
+            return;
+
+        var obstacles = ObstacleRegistrySystem.Obstacles;
+
+        float2 half = grid.AreaSize * 0.5f;
+        int2 bounds = (int2)half;
+        var rand = Unity.Mathematics.Random.CreateFromIndex((uint)(SystemAPI.Time.ElapsedTime * 1000 + 13));
+
+        bool TryFindNextStep(int2 start, int2 target, out int2 next)
+        {
+            next = start;
+            float best = float.MaxValue;
+            int2[] dirs = new int2[8]
+            {
+                new int2(1,0), new int2(-1,0), new int2(0,1), new int2(0,-1),
+                new int2(1,1), new int2(1,-1), new int2(-1,1), new int2(-1,-1)
+            };
+            for (int i = 0; i < 8; i++)
+            {
+                int2 cand = start + dirs[i];
+                if (math.abs(cand.x) > bounds.x || math.abs(cand.y) > bounds.y)
+                    continue;
+                if (obstacles.Contains(cand))
+                    continue;
+                float dist = math.lengthsq((float2)(target - cand));
+                if (dist < best)
+                {
+                    best = dist;
+                    next = cand;
+                }
+            }
+            return best < float.MaxValue;
+        }
+
+        foreach (var (transform, agent, gp, entity) in SystemAPI.Query<RefRW<LocalTransform>, RefRW<DebugAgent>, RefRW<GridPosition>>().WithEntityAccess())
+        {
+            int2 current = gp.ValueRO.Cell;
+
+            if (math.all(current == agent.ValueRO.Target))
+            {
+                int2 newTarget;
+                do
+                {
+                    newTarget = new int2(rand.NextInt(-bounds.x, bounds.x + 1), rand.NextInt(-bounds.y, bounds.y + 1));
+                } while (obstacles.Contains(newTarget));
+                agent.ValueRW.Target = newTarget;
+            }
+
+            // Dibujamos el camino hasta el objetivo.
+            int2 sim = current;
+            for (int i = 0; i < 128 && !math.all(sim == agent.ValueRO.Target); i++)
+            {
+                if (!TryFindNextStep(sim, agent.ValueRO.Target, out var step))
+                    break;
+                float3 a = new float3(sim.x, 0f, sim.y);
+                float3 b = new float3(step.x, 0f, step.y);
+                Debug.DrawLine(a, b, Color.cyan);
+                sim = step;
+            }
+
+            if (TryFindNextStep(current, agent.ValueRO.Target, out var next))
+            {
+                float3 world = new float3(next.x, 0f, next.y);
+                float3 pos = transform.ValueRO.Position;
+                float step = agent.ValueRO.MoveSpeed * SystemAPI.Time.DeltaTime;
+                float3 delta = world - pos;
+                float dist = math.length(delta);
+                if (dist <= step)
+                {
+                    transform.ValueRW.Position = world;
+                    gp.ValueRW.Cell = next;
+                }
+                else
+                {
+                    transform.ValueRW.Position = pos + delta / dist * step;
+                }
+            }
+        }
+    }
+}

--- a/Assets/1-Scripts/DOTS/Systems/DebugAgentSystem.cs.meta
+++ b/Assets/1-Scripts/DOTS/Systems/DebugAgentSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 206d514d9dca47828b5a7bc7807621f5

--- a/Assets/1-Scripts/DOTS/Systems/ObstacleRegistrySystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/ObstacleRegistrySystem.cs
@@ -1,0 +1,38 @@
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+
+/// Construye un registro de celdas ocupadas por obstáculos estáticos.
+public partial struct ObstacleRegistrySystem : ISystem
+{
+    public static NativeParallelHashSet<int2> Obstacles;
+
+    public void OnCreate(ref SystemState state)
+    {
+        Obstacles = new NativeParallelHashSet<int2>(1024, Allocator.Persistent);
+    }
+
+    public void OnDestroy(ref SystemState state)
+    {
+        if (Obstacles.IsCreated) Obstacles.Dispose();
+    }
+
+    private partial struct BuildObstacleJob : IJobEntity
+    {
+        public NativeParallelHashSet<int2>.ParallelWriter Obstacles;
+        void Execute(in GridPosition gp, in ObstacleTag tag)
+        {
+            Obstacles.Add(gp.Cell);
+        }
+    }
+
+    public void OnUpdate(ref SystemState state)
+    {
+        if (Obstacles.Count() > 0)
+            return;
+
+        var job = new BuildObstacleJob { Obstacles = Obstacles.AsParallelWriter() }.ScheduleParallel(state.Dependency);
+        state.Dependency = job;
+        state.Dependency.Complete();
+    }
+}

--- a/Assets/1-Scripts/DOTS/Systems/ObstacleRegistrySystem.cs.meta
+++ b/Assets/1-Scripts/DOTS/Systems/ObstacleRegistrySystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5008e425374641028f4a20dc76d2f0b2


### PR DESCRIPTION
## Summary
- add `DebugAgent` component and authoring to create debug entities
- spawn multiple debug agents with a manager and spawner system
- move agents toward random targets and draw their path for editor debugging
- build a one-time obstacle registry and update agent movement to use speed, avoid obstacles, and support smooth diagonal steps

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_b_68a0e3821b608326b26870ce4bdf1fa0