### PR TITLE
Prevent plants from spawning inside obstacles

### DIFF
--- a/Assets/1-Scripts/DOTS/Systems/PlantReproductionSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/PlantReproductionSystem.cs
@@ -35,7 +35,17 @@ public partial struct PlantReproductionSystem : ISystem
         var matureEntities = new NativeList<Entity>(Allocator.Temp);
         var maturePositions = new NativeList<float3>(Allocator.Temp);
         var occupied = new NativeParallelHashSet<int2>(manager.MaxPlants, Allocator.Temp);
-        // Reservamos las celdas que contienen obstáculos para impedir nacimientos allí.
+
+        // Incluimos celdas de obstáculos ya registrados para impedir nacimientos allí.
+        if (ObstacleRegistrySystem.Obstacles.IsCreated)
+        {
+            var obstacleCells = ObstacleRegistrySystem.Obstacles.ToNativeArray(Allocator.Temp);
+            for (int i = 0; i < obstacleCells.Length; i++)
+                occupied.Add(obstacleCells[i]);
+            obstacleCells.Dispose();
+        }
+
+        // Como respaldo, también consultamos los obstáculos existentes en la escena.
         foreach (var gp in SystemAPI.Query<RefRO<GridPosition>>().WithAll<ObstacleTag>())
             occupied.Add(gp.ValueRO.Cell);
 


### PR DESCRIPTION
## Summary
- Consult obstacle registry when plants reproduce to ensure new plants avoid blocked cells
- Preserve fallback obstacle query for runtime safety

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package dotnet-sdk-7.0)*

------
https://chatgpt.com/codex/tasks/task_b_68a0f015d33c8326ae4e841718251efb