### PR TITLE
Respect obstacle cells during spawning

### DIFF
--- a/Assets/1-Scripts/DOTS/Systems/PlantSpawnerSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/PlantSpawnerSystem.cs
@@ -45,10 +45,14 @@ public partial struct PlantSpawnerSystem : ISystem
 
         // Conjunto de celdas ocupadas y centros de cada parche.
         int2 half = (int2)(area / 2f);
-        var used = new NativeParallelHashSet<int2>(count, Allocator.Temp);
+        var obstacleQuery = SystemAPI.QueryBuilder().WithAll<GridPosition, ObstacleTag>().Build();
+        int obstacleCount = obstacleQuery.CalculateEntityCount();
+        var used = new NativeParallelHashSet<int2>(count + obstacleCount, Allocator.Temp);
         // Evitamos colocar plantas donde ya existen obstáculos.
-        foreach (var gp in SystemAPI.Query<RefRO<GridPosition>>().WithAll<ObstacleTag>())
-            used.Add(gp.ValueRO.Cell);
+        var obstacleCells = obstacleQuery.ToComponentDataArray<GridPosition>(Allocator.Temp);
+        for (int i = 0; i < obstacleCells.Length; i++)
+            used.Add(obstacleCells[i].Cell);
+        obstacleCells.Dispose();
 
         var centers = new NativeArray<float2>(patchCount, Allocator.Temp);
         for (int p = 0; p < patchCount; p++)


### PR DESCRIPTION
## Summary
- allocate occupied-cell sets with capacity for existing obstacles and plants
- ensure initial plant and herbivore spawners skip obstacle tiles

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a100669c948326bf70d6c3215f7cb9