### PR TITLE
refactor: rename debug agent to reusable movement template

### DIFF
--- a/Assets/1-Scripts/DOTS/Systems/ObstacleSpawnerSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/ObstacleSpawnerSystem.cs
@@ -5,26 +5,33 @@ using Unity.Mathematics;
 using Unity.Transforms;
 
 /// Sistema que genera obstáculos aleatorios en la cuadrícula al inicio.
+/// Los obstáculos se colocan en celdas libres y se marcan con `ObstacleTag`
+/// para que otros sistemas (como los agentes de depuración) los eviten.
 [BurstCompile]
 public partial struct ObstacleSpawnerSystem : ISystem
 {
     public void OnUpdate(ref SystemState state)
     {
+        // Obtener el manager de obstáculos y la información de la grilla.
         if (!SystemAPI.TryGetSingletonRW<ObstacleManager>(out var managerRw) ||
             !SystemAPI.TryGetSingleton<GridManager>(out var grid))
             return;
 
+        // Ejecutar solo una vez al inicio.
         if (managerRw.ValueRO.Initialized != 0)
             return;
 
         var manager = managerRw.ValueRO;
         var ecb = new EntityCommandBuffer(Allocator.Temp);
+        bool prefabHasGridPos = state.EntityManager.HasComponent<GridPosition>(manager.Prefab);
+        bool prefabHasObstacleTag = state.EntityManager.HasComponent<ObstacleTag>(manager.Prefab);
+        // Generador aleatorio con semilla fija para reproducibilidad.
         var rand = Unity.Mathematics.Random.CreateFromIndex(5);
 
         float2 area = grid.AreaSize;
         int2 half = (int2)(area / 2f);
 
-        // Celdas ya ocupadas por plantas u otros obstáculos.
+        // Celdas ya ocupadas por obstáculos existentes o plantas.
         var occupied = new NativeParallelHashSet<int2>(manager.Count, Allocator.Temp);
         foreach (var gp in SystemAPI.Query<RefRO<GridPosition>>().WithAll<ObstacleTag>())
             occupied.Add(gp.ValueRO.Cell);
@@ -40,18 +47,28 @@ public partial struct ObstacleSpawnerSystem : ISystem
             int2 cell = new int2(
                 rand.NextInt(-half.x, half.x + 1),
                 rand.NextInt(-half.y, half.y + 1));
+            // Si la celda ya está ocupada se intenta con otra.
             if (!occupied.Add(cell))
                 continue;
 
             var e = ecb.Instantiate(manager.Prefab);
             var pos = new float3(cell.x, 0f, cell.y);
+            // Posicionar el obstáculo en el mundo.
             ecb.SetComponent(e, LocalTransform.FromPositionRotationScale(pos, quaternion.identity, 1f));
-            ecb.AddComponent(e, new GridPosition { Cell = cell });
+            // Asegurar que tenga GridPosition.
+            if (prefabHasGridPos)
+                ecb.SetComponent(e, new GridPosition { Cell = cell });
+            else
+                ecb.AddComponent(e, new GridPosition { Cell = cell });
+            // Asegurar que posea la etiqueta de obstáculo.
+            if (!prefabHasObstacleTag)
+                ecb.AddComponent<ObstacleTag>(e);
             spawned++;
         }
 
         occupied.Dispose();
 
+        // Guardar que ya se generaron los obstáculos.
         manager.Initialized = 1;
         managerRw.ValueRW = manager;
         ecb.Playback(state.EntityManager);

--- a/Assets/1-Scripts/DOTS/Templates.meta
+++ b/Assets/1-Scripts/DOTS/Templates.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fe57fd05-9ad8-4fc9-88fd-7934cf2c9769
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/1-Scripts/DOTS/Templates/Movement.meta
+++ b/Assets/1-Scripts/DOTS/Templates/Movement.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7e0862f4-cded-4651-bce9-d4b793bc1595
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/1-Scripts/DOTS/Templates/Movement/Authoring.meta
+++ b/Assets/1-Scripts/DOTS/Templates/Movement/Authoring.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a4d9db3a-b6a9-43fc-8a80-374c6bb7c748
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/1-Scripts/DOTS/Templates/Movement/Authoring/MovementTemplateAgentAuthoring.cs
+++ b/Assets/1-Scripts/DOTS/Templates/Movement/Authoring/MovementTemplateAgentAuthoring.cs
@@ -1,0 +1,38 @@
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using UnityEngine;
+
+/// Autoría del prefab de la plantilla de movimiento.
+public class MovementTemplateAgentAuthoring : MonoBehaviour
+{
+    // Velocidad de movimiento base en celdas por segundo.
+    // El manager puede sobreescribir este valor para todas las instancias.
+    public float moveSpeed = 5f;
+
+    class Baker : Baker<MovementTemplateAgentAuthoring>
+    {
+        // Convierte el prefab de GameObject a una entidad con los componentes necesarios.
+        public override void Bake(MovementTemplateAgentAuthoring authoring)
+        {
+            // Crear una entidad dinámica para instanciar en tiempo de ejecución.
+            var entity = GetEntity(TransformUsageFlags.Dynamic);
+
+            // Registrar el componente de movimiento base con la velocidad inicial y sin objetivo.
+            AddComponent(entity, new MovementTemplateAgent
+            {
+                Target = int2.zero,
+                MoveSpeed = authoring.moveSpeed
+            });
+
+            // Añadir un buffer para almacenar el camino calculado entre celdas.
+            AddBuffer<MovementPathElement>(entity);
+
+            // Añadir un transform local para posicionar la entidad en el mundo.
+            AddComponent(entity, LocalTransform.FromPositionRotationScale(float3.zero, quaternion.identity, 1f));
+
+            // Cada agente necesita conocer la celda que ocupa en la grilla.
+            AddComponent(entity, new GridPosition { Cell = int2.zero });
+        }
+    }
+}

--- a/Assets/1-Scripts/DOTS/Templates/Movement/Authoring/MovementTemplateAgentAuthoring.cs.meta
+++ b/Assets/1-Scripts/DOTS/Templates/Movement/Authoring/MovementTemplateAgentAuthoring.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: eef10ca5045a4c0e854ec6c5781418b9

--- a/Assets/1-Scripts/DOTS/Templates/Movement/Authoring/MovementTemplateManagerAuthoring.cs
+++ b/Assets/1-Scripts/DOTS/Templates/Movement/Authoring/MovementTemplateManagerAuthoring.cs
@@ -1,0 +1,48 @@
+using Unity.Entities;
+using UnityEngine;
+
+/// Autoría para configurar la generación de entidades basadas en la plantilla de movimiento.
+public class MovementTemplateManagerAuthoring : MonoBehaviour
+{
+    // Prefab que implementa la plantilla de movimiento.
+    public GameObject agentPrefab;
+
+    // Número de instancias iniciales.
+    public int count = 5;
+
+    // Velocidad de movimiento que se aplicará a todas las instancias.
+    public float moveSpeed = 4f;
+
+    class Baker : Baker<MovementTemplateManagerAuthoring>
+    {
+        // Convierte los datos de la escena en componentes ECS.
+        public override void Bake(MovementTemplateManagerAuthoring authoring)
+        {
+            // Obtener la entidad que representará al manager.
+            var entity = GetEntity(TransformUsageFlags.None);
+
+            // Registrar un componente singleton con todos los parámetros necesarios
+            // para instanciar y configurar entidades que usen la plantilla de movimiento.
+            AddComponent(entity, new MovementTemplateManager
+            {
+                // Referencia al prefab convertido a entidad.
+                Prefab = GetEntity(authoring.agentPrefab, TransformUsageFlags.Dynamic),
+                // Cantidad de entidades a generar.
+                Count = authoring.count,
+                // Velocidad de movimiento común.
+                MoveSpeed = authoring.moveSpeed,
+                // Bandera utilizada para saber si ya se generaron las instancias.
+                Initialized = 0
+            });
+        }
+    }
+}
+
+/// Componente singleton que controla a las entidades que usan la plantilla de movimiento.
+public struct MovementTemplateManager : IComponentData
+{
+    public Entity Prefab;
+    public int Count;
+    public float MoveSpeed;
+    public byte Initialized;
+}

--- a/Assets/1-Scripts/DOTS/Templates/Movement/Authoring/MovementTemplateManagerAuthoring.cs.meta
+++ b/Assets/1-Scripts/DOTS/Templates/Movement/Authoring/MovementTemplateManagerAuthoring.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 193ac54b0b29428cbbff4297be0fd284

--- a/Assets/1-Scripts/DOTS/Templates/Movement/Components.meta
+++ b/Assets/1-Scripts/DOTS/Templates/Movement/Components.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 78de79a1-71b4-4109-944f-b79695f1484e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/1-Scripts/DOTS/Templates/Movement/Components/MovementPathElement.cs
+++ b/Assets/1-Scripts/DOTS/Templates/Movement/Components/MovementPathElement.cs
@@ -1,0 +1,9 @@
+using Unity.Entities;
+using Unity.Mathematics;
+
+/// Buffer que almacena el camino actual calculado para la plantilla de movimiento.
+[InternalBufferCapacity(16)]
+public struct MovementPathElement : IBufferElementData
+{
+    public int2 Cell;
+}

--- a/Assets/1-Scripts/DOTS/Templates/Movement/Components/MovementPathElement.cs.meta
+++ b/Assets/1-Scripts/DOTS/Templates/Movement/Components/MovementPathElement.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 720f0cef-2aa1-4c71-8636-509e833f4ebb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/1-Scripts/DOTS/Templates/Movement/Components/MovementTemplateAgent.cs
+++ b/Assets/1-Scripts/DOTS/Templates/Movement/Components/MovementTemplateAgent.cs
@@ -1,0 +1,17 @@
+using Unity.Entities;
+using Unity.Mathematics;
+
+/// Plantilla de movimiento base para entidades que recorren la cuadrícula.
+/// Esta estructura se utilizará como punto de partida para crear seres que
+/// se desplacen de forma eficiente y puedan reutilizar el sistema de
+/// pathfinding y movimiento.
+public struct MovementTemplateAgent : IComponentData
+{
+    /// Celda objetivo actual hacia la que se desplaza el agente.
+    public int2 Target;
+
+    /// Velocidad de movimiento en celdas por segundo.
+    /// Esta se inicializa desde el manager y puede variarse para todos
+    /// los agentes simultáneamente.
+    public float MoveSpeed;
+}

--- a/Assets/1-Scripts/DOTS/Templates/Movement/Components/MovementTemplateAgent.cs.meta
+++ b/Assets/1-Scripts/DOTS/Templates/Movement/Components/MovementTemplateAgent.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8988cd3f61cc4c60a9787401d954dc8f

--- a/Assets/1-Scripts/DOTS/Templates/Movement/Systems.meta
+++ b/Assets/1-Scripts/DOTS/Templates/Movement/Systems.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 83dffa52-a620-4c9a-8f0e-6ba391f26c4a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/1-Scripts/DOTS/Templates/Movement/Systems/MovementTemplateSpawnerSystem.cs
+++ b/Assets/1-Scripts/DOTS/Templates/Movement/Systems/MovementTemplateSpawnerSystem.cs
@@ -1,0 +1,70 @@
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+/// Genera las instancias configuradas por MovementTemplateManager.
+[BurstCompile]
+public partial struct MovementTemplateSpawnerSystem : ISystem
+{
+    public void OnUpdate(ref SystemState state)
+    {
+        // Comprobar que existan el manager y la información de la grilla.
+        if (!SystemAPI.TryGetSingletonRW<MovementTemplateManager>(out var managerRw) ||
+            !SystemAPI.TryGetSingleton<GridManager>(out var grid))
+            return;
+
+        // Evitar ejecutar más de una vez el spawner.
+        if (managerRw.ValueRO.Initialized != 0)
+            return;
+
+        var manager = managerRw.ValueRO;
+        var ecb = new EntityCommandBuffer(Allocator.Temp);
+
+        // Generador aleatorio fijo para obtener posiciones iniciales.
+        var rand = Unity.Mathematics.Random.CreateFromIndex(11);
+        float2 area = grid.AreaSize;
+        int2 half = (int2)(area / 2f);
+
+        // Datos base del prefab (sin modificar el prefab en sí).
+        var prefabData = state.EntityManager.GetComponentData<MovementTemplateAgent>(manager.Prefab);
+
+        // Instanciar la cantidad solicitada de entidades.
+        for (int i = 0; i < manager.Count; i++)
+        {
+            // Elegir una celda aleatoria dentro del área de juego.
+            int2 cell = new int2(
+                rand.NextInt(-half.x, half.x + 1),
+                rand.NextInt(-half.y, half.y + 1));
+
+            // Crear la entidad basada en el prefab.
+            var e = ecb.Instantiate(manager.Prefab);
+
+            // Posicionar la entidad en la celda seleccionada.
+            ecb.SetComponent(e, new LocalTransform
+            {
+                Position = new float3(cell.x, 0f, cell.y),
+                Rotation = quaternion.identity,
+                Scale = 1f
+            });
+
+            // Registrar la posición de la celda en el componente de grilla.
+            ecb.AddComponent(e, new GridPosition { Cell = cell });
+
+            // Asegurar que la entidad tenga un buffer de camino vacío.
+            ecb.SetBuffer<MovementPathElement>(e);
+
+            // Copiar los datos del prefab y personalizarlos para esta instancia.
+            var agent = prefabData;
+            agent.Target = cell; // El primer objetivo es su posición actual.
+            agent.MoveSpeed = manager.MoveSpeed; // Asignar velocidad desde el manager.
+            ecb.SetComponent(e, agent);
+        }
+
+        // Marcar que la generación ya se realizó para no repetirla.
+        manager.Initialized = 1;
+        managerRw.ValueRW = manager;
+        ecb.Playback(state.EntityManager);
+    }
+}

--- a/Assets/1-Scripts/DOTS/Templates/Movement/Systems/MovementTemplateSpawnerSystem.cs.meta
+++ b/Assets/1-Scripts/DOTS/Templates/Movement/Systems/MovementTemplateSpawnerSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 49872ea326264365aae34bd089fa7011

--- a/Assets/1-Scripts/DOTS/Templates/Movement/Systems/MovementTemplateSystem.cs
+++ b/Assets/1-Scripts/DOTS/Templates/Movement/Systems/MovementTemplateSystem.cs
@@ -1,0 +1,198 @@
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using UnityEngine;
+
+/// Sistema de movimiento reutilizable basado en la plantilla de agentes.
+[UpdateAfter(typeof(ObstacleRegistrySystem))]
+public partial struct MovementTemplateSystem : ISystem
+{
+    private static readonly int2[] Directions = new int2[8]
+    {
+        new int2(1,0), new int2(-1,0), new int2(0,1), new int2(0,-1),
+        new int2(1,1), new int2(1,-1), new int2(-1,1), new int2(-1,-1)
+    };
+    public void OnUpdate(ref SystemState state)
+    {
+        // Necesitamos la información de la grilla para limitar el movimiento.
+        if (!SystemAPI.TryGetSingleton<GridManager>(out var grid))
+            return;
+
+        // Copiar el registro de obstáculos a una variable local para usarlo en las búsquedas.
+        var obstacles = ObstacleRegistrySystem.Obstacles;
+
+        // Calcular los límites de la grilla (mitad del tamaño del área).
+        float2 half = grid.AreaSize * 0.5f;
+        int2 bounds = (int2)half;
+
+        // Crear un generador aleatorio que dependa del tiempo para variar los caminos.
+        var rand = Unity.Mathematics.Random.CreateFromIndex((uint)(SystemAPI.Time.ElapsedTime * 1000 + 13));
+
+        // Iterar sobre todas las entidades basadas en la plantilla de movimiento.
+        foreach (var (transform, agent, gp, path) in SystemAPI.Query<RefRW<LocalTransform>, RefRW<MovementTemplateAgent>, RefRW<GridPosition>, DynamicBuffer<MovementPathElement>>())
+        {
+            // Posición actual del agente en celdas.
+            int2 current = gp.ValueRO.Cell;
+
+            // Si ya llegó a su objetivo, seleccionar uno nuevo aleatorio y limpiar camino.
+            if (math.all(current == agent.ValueRO.Target))
+            {
+                int2 newTarget;
+                do
+                {
+                    newTarget = new int2(rand.NextInt(-bounds.x, bounds.x + 1), rand.NextInt(-bounds.y, bounds.y + 1));
+                } while (obstacles.Contains(newTarget));
+                agent.ValueRW.Target = newTarget;
+                path.Clear();
+            }
+
+            // Calcular el camino solo si no existe uno almacenado.
+            if (path.Length == 0)
+            {
+                if (!FindPath(current, agent.ValueRO.Target, obstacles, bounds, path))
+                {
+                    // Si falla, elegir otro objetivo y reintentar.
+                    int2 newTarget;
+                    do
+                    {
+                        newTarget = new int2(rand.NextInt(-bounds.x, bounds.x + 1), rand.NextInt(-bounds.y, bounds.y + 1));
+                    } while (obstacles.Contains(newTarget));
+                    agent.ValueRW.Target = newTarget;
+                    path.Clear();
+                    if (!FindPath(current, newTarget, obstacles, bounds, path))
+                        continue; // No se encontró camino, pasar a la siguiente entidad.
+                }
+            }
+
+            // Dibujar la ruta calculada en la vista de escena del editor.
+            for (int i = 0; i < path.Length - 1; i++)
+            {
+                float3 a = new float3(path[i].Cell.x, 0f, path[i].Cell.y);
+                float3 b = new float3(path[i + 1].Cell.x, 0f, path[i + 1].Cell.y);
+                Debug.DrawLine(a, b, Color.cyan);
+            }
+
+            // Desplazar suavemente al agente hacia la siguiente celda del camino.
+            if (path.Length > 1)
+            {
+                int2 next = path[1].Cell;
+                float3 world = new float3(next.x, 0f, next.y);
+                float3 pos = transform.ValueRO.Position;
+                float step = agent.ValueRO.MoveSpeed * SystemAPI.Time.DeltaTime;
+                float3 delta = world - pos;
+                float dist = math.length(delta);
+
+                // Orientar al agente hacia la dirección del movimiento para que avance "de frente".
+                if (dist > 0f)
+                    transform.ValueRW.Rotation = quaternion.LookRotationSafe(delta / dist, math.up());
+
+                if (dist <= step)
+                {
+                    // Llegó a la siguiente celda.
+                    transform.ValueRW.Position = world;
+                    gp.ValueRW.Cell = next;
+                    path.RemoveAt(0); // Avanzar en el buffer
+                }
+                else
+                {
+                    // Avanzar una fracción hacia la celda destino.
+                    transform.ValueRW.Position = pos + delta / dist * step;
+                }
+            }
+        }
+    }
+
+    private static bool FindPath(int2 start, int2 target, NativeParallelHashSet<int2> obstacles, int2 bounds, DynamicBuffer<MovementPathElement> path)
+    {
+        // Capacidad máxima estimada del grid para reservar memoria.
+        var capacity = (bounds.x * 2 + 1) * (bounds.y * 2 + 1);
+        var cameFrom = new NativeHashMap<int2, int2>(capacity, Allocator.Temp);
+        var frontier = new NativeQueue<int2>(Allocator.Temp);
+        var tmpPath = new NativeList<int2>(Allocator.Temp);
+
+        // Inicializar la búsqueda con la celda de partida.
+        frontier.Enqueue(start);
+        cameFrom.TryAdd(start, start);
+
+        bool found = false;
+
+        // Búsqueda en anchura clásica (BFS).
+        while (frontier.TryDequeue(out var current))
+        {
+            if (math.all(current == target))
+            {
+                found = true;
+                break; // Se alcanzó el objetivo.
+            }
+
+            // Explorar las celdas vecinas.
+            for (int i = 0; i < Directions.Length; i++)
+            {
+                int2 dir = Directions[i];
+                int2 next = current + dir;
+
+                // Ignorar si está fuera de los límites.
+                if (math.abs(next.x) > bounds.x || math.abs(next.y) > bounds.y)
+                    continue;
+
+                // Ignorar celdas ocupadas por obstáculos.
+                if (obstacles.Contains(next))
+                    continue;
+
+                // Para diagonales, evitar "cortar esquinas".
+                if (math.abs(dir.x) == 1 && math.abs(dir.y) == 1)
+                {
+                    int2 sideA = current + new int2(dir.x, 0);
+                    int2 sideB = current + new int2(0, dir.y);
+                    if (obstacles.Contains(sideA) || obstacles.Contains(sideB))
+                        continue;
+                }
+
+                // Si ya se visitó, continuar.
+                if (cameFrom.ContainsKey(next))
+                    continue;
+
+                // Registrar de dónde venimos y añadir a la cola.
+                cameFrom.TryAdd(next, current);
+                frontier.Enqueue(next);
+            }
+        }
+
+        // Si no se encontró camino, liberar recursos y salir.
+        if (!found)
+        {
+            frontier.Dispose();
+            cameFrom.Dispose();
+            tmpPath.Dispose();
+            path.Clear();
+            return false;
+        }
+
+        // Reconstruir el camino desde el objetivo hasta el origen.
+        int2 p = target;
+        while (!math.all(p == start))
+        {
+            tmpPath.Add(p);
+            p = cameFrom[p];
+        }
+        tmpPath.Add(start);
+
+        // Invertir manualmente para que quede desde el origen al destino.
+        for (int i = 0, j = tmpPath.Length - 1; i < j; i++, j--)
+        {
+            int2 tmp = tmpPath[i];
+            tmpPath[i] = tmpPath[j];
+            tmpPath[j] = tmp;
+        }
+
+        path.Clear();
+        for (int i = 0; i < tmpPath.Length; i++)
+            path.Add(new MovementPathElement { Cell = tmpPath[i] });
+
+        frontier.Dispose();
+        cameFrom.Dispose();
+        tmpPath.Dispose();
+        return true;
+    }
+}

--- a/Assets/1-Scripts/DOTS/Templates/Movement/Systems/MovementTemplateSystem.cs.meta
+++ b/Assets/1-Scripts/DOTS/Templates/Movement/Systems/MovementTemplateSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 206d514d9dca47828b5a7bc7807621f5

--- a/Assets/1-Scripts/DOTS/Templates/Movement/Systems/ObstacleRegistrySystem.cs
+++ b/Assets/1-Scripts/DOTS/Templates/Movement/Systems/ObstacleRegistrySystem.cs
@@ -1,0 +1,47 @@
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+
+/// Construye un registro de celdas ocupadas por obstáculos estáticos para que
+/// los sistemas de movimiento basados en la plantilla puedan consultarlo rápidamente.
+[UpdateAfter(typeof(ObstacleSpawnerSystem))]
+public partial struct ObstacleRegistrySystem : ISystem
+{
+    // Conjunto compartido con las celdas bloqueadas.
+    public static NativeParallelHashSet<int2> Obstacles;
+
+    public void OnCreate(ref SystemState state)
+    {
+        // Reservar memoria persistente para almacenar hasta 1024 obstáculos.
+        Obstacles = new NativeParallelHashSet<int2>(1024, Allocator.Persistent);
+    }
+
+    public void OnDestroy(ref SystemState state)
+    {
+        // Liberar la memoria cuando el sistema se destruye.
+        if (Obstacles.IsCreated) Obstacles.Dispose();
+    }
+
+    // Job que recorre todas las entidades con GridPosition y ObstacleTag
+    // para añadir su celda al conjunto.
+    private partial struct BuildObstacleJob : IJobEntity
+    {
+        public NativeParallelHashSet<int2>.ParallelWriter Obstacles;
+        void Execute(in GridPosition gp, in ObstacleTag tag)
+        {
+            Obstacles.Add(gp.Cell);
+        }
+    }
+
+    public void OnUpdate(ref SystemState state)
+    {
+        // Solo construir una vez; si ya hay datos en el conjunto se omite.
+        if (Obstacles.Count() > 0)
+            return;
+
+        // Programar el job para recolectar todos los obstáculos existentes.
+        var job = new BuildObstacleJob { Obstacles = Obstacles.AsParallelWriter() }.ScheduleParallel(state.Dependency);
+        state.Dependency = job;
+        state.Dependency.Complete();
+    }
+}

--- a/Assets/1-Scripts/DOTS/Templates/Movement/Systems/ObstacleRegistrySystem.cs.meta
+++ b/Assets/1-Scripts/DOTS/Templates/Movement/Systems/ObstacleRegistrySystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5008e425374641028f4a20dc76d2f0b2


### PR DESCRIPTION
## Summary
- promote former debug agent into a reusable movement template with manager, spawner, and obstacle registry
- cache paths in a dynamic buffer and reuse shared obstacle registry to cut per-frame allocations and recomputation
- add movement path buffer component and organize template scripts under a dedicated folder

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_b_68a0e3821b608326b26870ce4bdf1fa0