### PR TITLE
Restore smooth DOTS plant growth

### DIFF
--- a/Assets/1-Scripts/DOTS/Authoring/PlantAuthoring.cs
+++ b/Assets/1-Scripts/DOTS/Authoring/PlantAuthoring.cs
@@ -24,20 +24,21 @@ public class PlantAuthoring : MonoBehaviour
         {
             var entity = GetEntity(TransformUsageFlags.Dynamic);
 
+            // Porcentaje mínimo para asegurar visibilidad.
+            float initialPercent = math.max(authoring.initialEnergyPercent, 0.2f);
+
             // Componentes de energía de la planta.
             AddComponent(entity, new Plant
             {
-                Energy = authoring.maxEnergy * authoring.initialEnergyPercent,
+                Energy = authoring.maxEnergy * initialPercent,
                 MaxEnergy = authoring.maxEnergy,
                 EnergyGainRate = authoring.energyGainRate,
-                ScaleStep = 1,
                 Stage = PlantStage.Growing,
                 BeingEaten = 0
             });
 
             // Transform inicial según el porcentaje de energía.
-            float initialScale = math.max(authoring.initialEnergyPercent, 0.2f);
-            AddComponent(entity, LocalTransform.FromPositionRotationScale(float3.zero, quaternion.identity, initialScale));
+            AddComponent(entity, LocalTransform.FromPositionRotationScale(float3.zero, quaternion.identity, initialPercent));
 
             // Color inicial para indicar estado de crecimiento.
             AddComponent(entity, new URPMaterialPropertyBaseColor { Value = new float4(1f, 1f, 0f, 1f) });

--- a/Assets/1-Scripts/DOTS/Components/Plant.cs
+++ b/Assets/1-Scripts/DOTS/Components/Plant.cs
@@ -15,9 +15,6 @@ public struct Plant : IComponentData
     public float MaxEnergy;  // Energía máxima
     public float EnergyGainRate; // Velocidad de obtención de energía
 
-    /// Último escalón de escala aplicado (1..5) para evitar cambios cada frame.
-    public byte ScaleStep;
-
     /// Estado visual/biológico actual.
     public PlantStage Stage;
 

--- a/Assets/1-Scripts/DOTS/Systems/PlantEnergySystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/PlantEnergySystem.cs
@@ -47,15 +47,9 @@ public partial struct PlantEnergySystem : ISystem
 
             plant.ValueRW.BeingEaten = 0;
 
-            // Ajusta la escala visual solo cuando cambia lo suficiente.
+            // Ajusta la escala visual de forma continua según la energía.
             float percent = math.clamp(plant.ValueRO.Energy / plant.ValueRO.MaxEnergy, 0f, 1f);
-            int step = (int)math.floor(percent * 10f);
-            if (step < 1) step = 1;
-            if (plant.ValueRO.ScaleStep != step)
-            {
-                transform.ValueRW.Scale = step / 10f;
-                plant.ValueRW.ScaleStep = (byte)step;
-            }
+            transform.ValueRW.Scale = percent;
         }
 
         ecb.Playback(state.EntityManager);

--- a/Assets/1-Scripts/DOTS/Systems/PlantReproductionSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/PlantReproductionSystem.cs
@@ -124,15 +124,14 @@ public partial struct PlantReproductionSystem : ISystem
                         var template = state.EntityManager.GetComponentData<Plant>(manager.Prefab);
                         template.MaxEnergy = manager.PlantMaxEnergy;
                         template.EnergyGainRate = manager.PlantEnergyGainRate;
-                        template.Energy = manager.PlantMaxEnergy * manager.InitialEnergyPercent;
-                        template.ScaleStep = 1;
+                        float initialPercent = math.max(manager.InitialEnergyPercent, 0.2f);
+                        template.Energy = manager.PlantMaxEnergy * initialPercent;
                         template.Stage = PlantStage.Growing;
-                        float scale = math.max(manager.InitialEnergyPercent, 0.2f);
                         ecb.SetComponent(child, template);
-                        ecb.SetComponent(child, LocalTransform.FromPositionRotationScale(pos, quaternion.identity, scale));
+                        ecb.SetComponent(child, LocalTransform.FromPositionRotationScale(pos, quaternion.identity, initialPercent));
                         ecb.SetComponent(child, new LocalToWorld
                         {
-                            Value = float4x4.TRS(pos, quaternion.identity, new float3(scale))
+                            Value = float4x4.TRS(pos, quaternion.identity, new float3(initialPercent))
                         });
                         ecb.AddComponent(child, new GridPosition { Cell = cell });
 
@@ -189,15 +188,14 @@ public partial struct PlantReproductionSystem : ISystem
                     var template = state.EntityManager.GetComponentData<Plant>(manager.Prefab);
                     template.MaxEnergy = manager.PlantMaxEnergy;
                     template.EnergyGainRate = manager.PlantEnergyGainRate;
-                    template.Energy = manager.PlantMaxEnergy * manager.InitialEnergyPercent;
-                    template.ScaleStep = 1;
+                    float initialPercent = math.max(manager.InitialEnergyPercent, 0.2f);
+                    template.Energy = manager.PlantMaxEnergy * initialPercent;
                     template.Stage = PlantStage.Growing;
-                    float scale = math.max(manager.InitialEnergyPercent, 0.2f);
                     ecb.SetComponent(child, template);
-                    ecb.SetComponent(child, LocalTransform.FromPositionRotationScale(pos, quaternion.identity, scale));
+                    ecb.SetComponent(child, LocalTransform.FromPositionRotationScale(pos, quaternion.identity, initialPercent));
                     ecb.SetComponent(child, new LocalToWorld
                     {
-                        Value = float4x4.TRS(pos, quaternion.identity, new float3(scale))
+                        Value = float4x4.TRS(pos, quaternion.identity, new float3(initialPercent))
                     });
                     ecb.AddComponent(child, new GridPosition { Cell = cell });
 

--- a/Assets/1-Scripts/DOTS/Systems/PlantSpawnerSystem.cs
+++ b/Assets/1-Scripts/DOTS/Systems/PlantSpawnerSystem.cs
@@ -38,10 +38,10 @@ public partial struct PlantSpawnerSystem : ISystem
         var prefabPlant = state.EntityManager.GetComponentData<Plant>(prefab);
         prefabPlant.MaxEnergy = manager.PlantMaxEnergy;
         prefabPlant.EnergyGainRate = manager.PlantEnergyGainRate;
-        prefabPlant.Energy = manager.PlantMaxEnergy * manager.InitialEnergyPercent;
-        prefabPlant.ScaleStep = 1;
+        float initialPercent = math.max(manager.InitialEnergyPercent, 0.2f);
+        prefabPlant.Energy = manager.PlantMaxEnergy * initialPercent;
         prefabPlant.Stage = PlantStage.Growing;
-        float initialScale = math.max(manager.InitialEnergyPercent, 0.2f);
+        float initialScale = initialPercent;
 
         // Conjunto de celdas ocupadas y centros de cada parche.
         int2 half = (int2)(area / 2f);


### PR DESCRIPTION
## Summary
- Remove step-based scaling from DOTS plants and compute scale directly from energy
- Initialize new plants with matching energy and scale for smooth growth

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_b_68a10cf8f9dc832690843fdd3ba3d25f