### PR TITLE
Refactor herbivore behavior to use template agent pathing

### DIFF
--- a/Assets/1-Scripts/ECO_DOTS/Authoring/HerbivoreAuthoring.cs
+++ b/Assets/1-Scripts/ECO_DOTS/Authoring/HerbivoreAuthoring.cs
@@ -85,7 +85,10 @@ public class HerbivoreAuthoring : MonoBehaviour
                 MoveRemainder = float3.zero,
                 KnownPlantCell = int2.zero,
                 HasKnownPlant = 0,
-                IsEating = 0
+                IsEating = 0,
+                Target = int2.zero,
+                WaitTimer = 0f,
+                PathIndex = 0
             });
 
             AddComponent(entity, new HerbivoreState
@@ -151,6 +154,9 @@ public class HerbivoreAuthoring : MonoBehaviour
             // Transform y posición inicial del herbívoro.
             AddComponent(entity, LocalTransform.FromPositionRotationScale(float3.zero, quaternion.identity, 1f));
             AddComponent(entity, new GridPosition { Cell = int2.zero });
+
+            // Buffer de ruta para que el herbívoro pueda almacenar sus destinos.
+            AddBuffer<PathBufferElement>(entity);
 
             // Etiqueta y color inicial.
 

--- a/Assets/1-Scripts/ECO_DOTS/Authoring/TemplateAgentAuthoring.cs
+++ b/Assets/1-Scripts/ECO_DOTS/Authoring/TemplateAgentAuthoring.cs
@@ -22,7 +22,9 @@ public class TemplateAgentAuthoring : MonoBehaviour
             AddComponent(entity, new TemplateAgent
             {
                 Target = int2.zero,
-                MoveSpeed = authoring.moveSpeed
+                MoveSpeed = authoring.moveSpeed,
+                WaitTimer = 0f,
+                PathIndex = 0
             });
 
             // Añadir un transform local para posicionar la entidad en el mundo.
@@ -30,6 +32,9 @@ public class TemplateAgentAuthoring : MonoBehaviour
 
             // Cada agente necesita conocer la celda que ocupa en la grilla.
             AddComponent(entity, new GridPosition { Cell = int2.zero });
+
+            // Buffer para almacenar las celdas del camino a seguir.
+            AddBuffer<PathBufferElement>(entity);
         }
     }
 }

--- a/Assets/1-Scripts/ECO_DOTS/Components/Herbivore.cs
+++ b/Assets/1-Scripts/ECO_DOTS/Components/Herbivore.cs
@@ -42,4 +42,13 @@ public struct Herbivore : IComponentData
 
     /// Indicador de si actualmente está comiendo una planta.
     public byte IsEating;
+
+    /// Celda objetivo actual para navegación.
+    public int2 Target;
+
+    /// Tiempo de espera antes de buscar un nuevo objetivo.
+    public float WaitTimer;
+
+    /// Índice de la siguiente celda dentro del buffer de ruta.
+    public int PathIndex;
 }

--- a/Assets/1-Scripts/ECO_DOTS/Components/PathBufferElement.cs
+++ b/Assets/1-Scripts/ECO_DOTS/Components/PathBufferElement.cs
@@ -1,0 +1,10 @@
+using Unity.Entities;
+using Unity.Mathematics;
+
+/// Ruta almacenada para que un agente pueda recorrerla sin recalcular cada frame.
+[InternalBufferCapacity(16)]
+public struct PathBufferElement : IBufferElementData
+{
+    /// Celda de la ruta que debe seguir el agente.
+    public int2 Cell;
+}

--- a/Assets/1-Scripts/ECO_DOTS/Components/TemplateAgent.cs
+++ b/Assets/1-Scripts/ECO_DOTS/Components/TemplateAgent.cs
@@ -13,4 +13,10 @@ public struct TemplateAgent : IComponentData
     /// Esta se inicializa desde el manager y puede variarse para todos
     /// los agentes simultáneamente.
     public float MoveSpeed;
+
+    /// Tiempo de espera antes de elegir un nuevo objetivo.
+    public float WaitTimer;
+
+    /// Índice del siguiente nodo dentro del buffer de ruta.
+    public int PathIndex;
 }

--- a/Assets/1-Scripts/ECO_DOTS/Systems/HerbivoreSpawnerSystem.cs
+++ b/Assets/1-Scripts/ECO_DOTS/Systems/HerbivoreSpawnerSystem.cs
@@ -25,6 +25,9 @@ public partial struct HerbivoreSpawnerSystem : ISystem
         var ecb = new EntityCommandBuffer(Allocator.Temp);
         var rand = Unity.Mathematics.Random.CreateFromIndex(3);
 
+        // Datos base del prefab para personalizar cada instancia.
+        var prefabData = state.EntityManager.GetComponentData<Herbivore>(manager.Prefab);
+
         // Rango del área jugable en celdas.
         float2 area = grid.AreaSize;
         int2 half = (int2)(area / 2f);
@@ -60,6 +63,18 @@ public partial struct HerbivoreSpawnerSystem : ISystem
                 Scale = 1f
             });
             ecb.AddComponent(e, new GridPosition { Cell = cell });
+
+            // Personalizar los datos del herbívoro para esta instancia.
+            var herb = prefabData;
+            herb.Target = cell;
+            herb.WaitTimer = rand.NextFloat(0f, 1f);
+            herb.PathIndex = 0;
+            ecb.SetComponent(e, herb);
+
+            // Buffer de ruta inicial con la celda actual.
+            var path = ecb.AddBuffer<PathBufferElement>(e);
+            path.Add(new PathBufferElement { Cell = cell });
+
             ecb.SetComponent(e, new HerbivoreInfo
             {
                 Name = HerbivoreNameGenerator.NextName(),

--- a/Assets/1-Scripts/ECO_DOTS/Systems/HerbivoreSystem.cs
+++ b/Assets/1-Scripts/ECO_DOTS/Systems/HerbivoreSystem.cs
@@ -5,7 +5,7 @@ using Unity.Mathematics;
 using Unity.Transforms;
 
 /// Gestiona el movimiento, hambre y alimentación de los herbívoros DOTS.
-[BurstCompile]
+[BurstCompile, DisableAutoCreation]
 public partial struct HerbivoreSystem : ISystem
 {
     private NativeParallelMultiHashMap<int2, Entity> _plants;

--- a/Assets/1-Scripts/ECO_DOTS/Systems/HerbivoreTemplateSystem.cs
+++ b/Assets/1-Scripts/ECO_DOTS/Systems/HerbivoreTemplateSystem.cs
@@ -1,0 +1,237 @@
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using UnityEngine;
+
+/// Sistema simplificado de movimiento y comportamiento para herbívoros basado en TemplateAgent.
+[UpdateAfter(typeof(ObstacleRegistrySystem))]
+public partial struct HerbivoreTemplateSystem : ISystem
+{
+    public void OnUpdate(ref SystemState state)
+    {
+        if (!SystemAPI.TryGetSingleton<GridManager>(out var grid) ||
+            !SystemAPI.TryGetSingleton<HerbivoreManager>(out var hManager))
+            return;
+
+        var obstacles = ObstacleRegistrySystem.Obstacles;
+        var rand = Unity.Mathematics.Random.CreateFromIndex((uint)(SystemAPI.Time.ElapsedTime * 1000 + 7));
+        float2 half = grid.AreaSize * 0.5f;
+        int2 bounds = (int2)half;
+        float dt = SystemAPI.Time.DeltaTime;
+
+        // Construir un mapa de plantas para búsquedas rápidas.
+        var plantQuery = SystemAPI.QueryBuilder().WithAll<Plant, GridPosition>().Build();
+        int plantCount = plantQuery.CalculateEntityCount();
+        var plantMap = new NativeParallelHashMap<int2, Entity>(plantCount, Allocator.Temp);
+        foreach (var (gp, entity) in SystemAPI.Query<RefRO<GridPosition>>().WithAll<Plant>().WithEntityAccess())
+        {
+            plantMap.TryAdd(gp.ValueRO.Cell, entity);
+        }
+
+        var ecb = new EntityCommandBuffer(Allocator.Temp);
+
+        foreach (var (transform, herb, gp, energy, repro, path) in SystemAPI
+                 .Query<RefRW<LocalTransform>, RefRW<Herbivore>, RefRW<GridPosition>, RefRW<Energy>, RefRW<Reproduction>, DynamicBuffer<PathBufferElement>>())
+        {
+            int2 current = gp.ValueRO.Cell;
+
+            if (path.Length == 0)
+            {
+                path.Add(new PathBufferElement { Cell = current });
+                herb.ValueRW.PathIndex = 0;
+            }
+
+            // Comer si hay planta en la celda actual.
+            if (plantMap.TryGetValue(current, out var plantEntity))
+            {
+                energy.ValueRW.Value = math.min(energy.ValueRO.Max, energy.ValueRO.Value + herb.ValueRO.EatEnergyRate * dt);
+                if (energy.ValueRO.Value >= energy.ValueRO.Max)
+                {
+                    ecb.DestroyEntity(plantEntity);
+                    plantMap.Remove(current);
+                }
+            }
+
+            // Reproducción simple sin pareja.
+            repro.ValueRW.Timer = math.max(0f, repro.ValueRO.Timer - dt);
+            if (energy.ValueRO.Value >= repro.ValueRO.Threshold && repro.ValueRO.Timer <= 0f)
+            {
+                var child = ecb.Instantiate(hManager.Prefab);
+                ecb.SetComponent(child, new LocalTransform
+                {
+                    Position = transform.ValueRO.Position,
+                    Rotation = quaternion.identity,
+                    Scale = 1f
+                });
+                ecb.AddComponent(child, new GridPosition { Cell = current });
+                var childHerb = herb.ValueRO;
+                childHerb.Target = current;
+                childHerb.WaitTimer = rand.NextFloat(0f, 1f);
+                childHerb.PathIndex = 0;
+                ecb.SetComponent(child, childHerb);
+                var childPath = ecb.AddBuffer<PathBufferElement>(child);
+                childPath.Add(new PathBufferElement { Cell = current });
+
+                energy.ValueRW.Value *= (1f - repro.ValueRO.EnergyCostPercent);
+                repro.ValueRW.Timer = repro.ValueRO.Cooldown;
+            }
+
+            // Si terminó la ruta, decidir nuevo objetivo.
+            if (herb.ValueRO.PathIndex >= path.Length)
+            {
+                herb.ValueRW.WaitTimer -= dt;
+                if (herb.ValueRO.WaitTimer > 0f)
+                    continue;
+
+                int2 newTarget = current;
+                bool seekFood = energy.ValueRO.Value < energy.ValueRO.SeekThreshold;
+                if (seekFood)
+                {
+                    float bestDist = float.MaxValue;
+                    int2 bestCell = current;
+                    var keys = plantMap.GetKeyArray(Allocator.Temp);
+                    float radiusSq = herb.ValueRO.PlantSeekRadius * herb.ValueRO.PlantSeekRadius;
+                    for (int i = 0; i < keys.Length; i++)
+                    {
+                        float dist = math.lengthsq((float2)(keys[i] - current));
+                        if (dist < bestDist && dist <= radiusSq)
+                        {
+                            bestDist = dist;
+                            bestCell = keys[i];
+                        }
+                    }
+                    keys.Dispose();
+                    if (bestDist < float.MaxValue)
+                        newTarget = bestCell;
+                    else
+                        newTarget = new int2(rand.NextInt(-bounds.x, bounds.x + 1), rand.NextInt(-bounds.y, bounds.y + 1));
+                }
+                else
+                {
+                    newTarget = new int2(rand.NextInt(-bounds.x, bounds.x + 1), rand.NextInt(-bounds.y, bounds.y + 1));
+                }
+
+                herb.ValueRW.Target = newTarget;
+                herb.ValueRW.WaitTimer = rand.NextFloat(0.5f, 1.5f);
+
+                if (FindPath(current, newTarget, obstacles, bounds, out var newPath))
+                {
+                    path.Clear();
+                    for (int i = 0; i < newPath.Length; i++)
+                        path.Add(new PathBufferElement { Cell = newPath[i] });
+                    herb.ValueRW.PathIndex = math.min(1, path.Length);
+                    newPath.Dispose();
+                }
+                else
+                {
+                    herb.ValueRW.PathIndex = path.Length;
+                }
+            }
+
+            // Movimiento suave a lo largo del camino.
+            if (herb.ValueRO.PathIndex < path.Length)
+            {
+                int2 next = path[herb.ValueRO.PathIndex].Cell;
+                float3 world = new float3(next.x, 0f, next.y);
+                float3 pos = transform.ValueRO.Position;
+                float step = herb.ValueRO.MoveSpeed * dt;
+                float3 delta = world - pos;
+                float dist = math.length(delta);
+
+                if (dist > 0f)
+                    transform.ValueRW.Rotation = quaternion.LookRotationSafe(delta / dist, math.up());
+
+                if (dist <= step)
+                {
+                    transform.ValueRW.Position = world;
+                    gp.ValueRW.Cell = next;
+                    herb.ValueRW.PathIndex++;
+                }
+                else
+                {
+                    transform.ValueRW.Position = pos + delta / dist * step;
+                }
+            }
+        }
+
+        ecb.Playback(state.EntityManager);
+        plantMap.Dispose();
+    }
+
+    private static bool FindPath(int2 start, int2 target, NativeParallelHashSet<int2> obstacles, int2 bounds, out NativeList<int2> path)
+    {
+        var capacity = (bounds.x * 2 + 1) * (bounds.y * 2 + 1);
+        var cameFrom = new NativeHashMap<int2, int2>(capacity, Allocator.Temp);
+        var frontier = new NativeQueue<int2>(Allocator.Temp);
+        path = new NativeList<int2>(Allocator.Temp);
+
+        frontier.Enqueue(start);
+        cameFrom.TryAdd(start, start);
+
+        int2[] dirs = new int2[8]
+        {
+            new int2(1,0), new int2(-1,0), new int2(0,1), new int2(0,-1),
+            new int2(1,1), new int2(1,-1), new int2(-1,1), new int2(-1,-1)
+        };
+
+        bool found = false;
+        while (frontier.TryDequeue(out var current))
+        {
+            if (math.all(current == target))
+            {
+                found = true;
+                break;
+            }
+
+            for (int i = 0; i < 8; i++)
+            {
+                int2 dir = dirs[i];
+                int2 next = current + dir;
+                if (math.abs(next.x) > bounds.x || math.abs(next.y) > bounds.y)
+                    continue;
+                if (obstacles.Contains(next))
+                    continue;
+                if (math.abs(dir.x) == 1 && math.abs(dir.y) == 1)
+                {
+                    int2 sideA = current + new int2(dir.x, 0);
+                    int2 sideB = current + new int2(0, dir.y);
+                    if (obstacles.Contains(sideA) || obstacles.Contains(sideB))
+                        continue;
+                }
+                if (cameFrom.ContainsKey(next))
+                    continue;
+                cameFrom.TryAdd(next, current);
+                frontier.Enqueue(next);
+            }
+        }
+
+        if (!found)
+        {
+            frontier.Dispose();
+            cameFrom.Dispose();
+            path.Dispose();
+            path = default;
+            return false;
+        }
+
+        int2 p = target;
+        while (!math.all(p == start))
+        {
+            path.Add(p);
+            p = cameFrom[p];
+        }
+        path.Add(start);
+
+        for (int i = 0, j = path.Length - 1; i < j; i++, j--)
+        {
+            int2 tmp = path[i];
+            path[i] = path[j];
+            path[j] = tmp;
+        }
+
+        frontier.Dispose();
+        cameFrom.Dispose();
+        return true;
+    }
+}

--- a/Assets/1-Scripts/ECO_DOTS/Systems/TemplateAgentSpawnerSystem.cs
+++ b/Assets/1-Scripts/ECO_DOTS/Systems/TemplateAgentSpawnerSystem.cs
@@ -56,6 +56,8 @@ public partial struct TemplateAgentSpawnerSystem : ISystem
             var agent = prefabData;
             agent.Target = cell; // El primer objetivo es su posición actual.
             agent.MoveSpeed = manager.MoveSpeed; // Asignar velocidad desde el manager.
+            agent.WaitTimer = rand.NextFloat(0f, 1f); // Escalonar el cálculo de rutas.
+            agent.PathIndex = 0;
             ecb.SetComponent(e, agent);
         }
 


### PR DESCRIPTION
## Summary
- Add navigation fields to `Herbivore` and initialize them from authoring
- Spawn herbivores with initial path buffers and template-style data
- Disable old herbivore system and add new `HerbivoreTemplateSystem` with pathfinding, feeding and reproduction

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_68a126e9012c832686d5e6ce705fe556